### PR TITLE
fix: resolve Dynamic MCP timeout causing meta-tools to be unavailable

### DIFF
--- a/apps/api/src/app/api/endpoints/mcp_proxy.py
+++ b/apps/api/src/app/api/endpoints/mcp_proxy.py
@@ -418,6 +418,22 @@ async def apply_prompts_merging(data: Dict[str, Any]) -> Dict[str, Any]:
     return data
 
 
+async def _refresh_dynamic_mcp_cache(process_manager, docker_tools: list):
+    """Background task to refresh Dynamic MCP cache without blocking response."""
+    try:
+        dynamic_mcp = get_dynamic_mcp()
+        await dynamic_mcp.refresh_cache_hot_only(process_manager, docker_tools)
+
+        # Store schemas for cached tools
+        for tool_name, tool_info in dynamic_mcp._tools.items():
+            schema_partitioner.store_full_schema(tool_name, tool_info.input_schema)
+            schema_partitioner.store_tool_description(tool_name, tool_info.description)
+
+        print(f"[Dynamic MCP] Background cache refresh complete: {len(dynamic_mcp._tools)} tools")
+    except Exception as e:
+        print(f"[Dynamic MCP] Background cache refresh failed: {e}")
+
+
 async def apply_schema_partitioning(data: Dict[str, Any]) -> Dict[str, Any]:
     """
     tools/list レスポンスにschema partitioning適用 + Process MCPツール統合
@@ -435,27 +451,20 @@ async def apply_schema_partitioning(data: Dict[str, Any]) -> Dict[str, Any]:
     docker_tools = list(data["result"]["tools"])
     process_manager = get_process_manager()
 
-    # Dynamic MCP mode: return only meta-tools
+    # Dynamic MCP mode: return only meta-tools (FAST PATH)
     if settings.DYNAMIC_MCP:
         print("[Dynamic MCP] Mode enabled - returning meta-tools only")
 
-        # Get ALL tools for caching (from all enabled servers, not just HOT)
-        all_process_tools = await process_manager.list_tools(mode="all")
-
-        # Refresh Dynamic MCP cache with all available tools
+        # Return meta-tools IMMEDIATELY (no blocking operations)
         dynamic_mcp = get_dynamic_mcp()
-        await dynamic_mcp.refresh_cache(process_manager, docker_tools)
+        meta_tools = dynamic_mcp.get_meta_tools()
+        data["result"]["tools"] = meta_tools
+        print(f"[Dynamic MCP] Returning {len(meta_tools)} meta-tools immediately")
 
-        # Also store full schemas for airis-schema lookups
-        for tool in docker_tools + all_process_tools:
-            tool_name = tool.get("name", "")
-            if tool_name:
-                schema_partitioner.store_full_schema(tool_name, tool.get("inputSchema", {}))
-                schema_partitioner.store_tool_description(tool_name, tool.get("description", ""))
+        # Schedule background cache refresh (non-blocking)
+        import asyncio
+        asyncio.create_task(_refresh_dynamic_mcp_cache(process_manager, docker_tools))
 
-        # Return only meta-tools
-        data["result"]["tools"] = dynamic_mcp.get_meta_tools()
-        print(f"[Dynamic MCP] Cached {len(docker_tools)} docker + {len(all_process_tools)} process tools, returning 3 meta-tools")
         return data
 
     # Standard mode: merge HOT tools and apply schema partitioning
@@ -936,13 +945,13 @@ async def _proxy_jsonrpc_request(request: Request) -> Response:
 
         # Dynamic MCP meta-tools (only when DYNAMIC_MCP=true)
         if tool_name == "airis-find":
-            return await handle_airis_find(rpc_request)
+            return await handle_airis_find(rpc_request, session_id=session_id)
 
         if tool_name == "airis-exec":
             return await handle_airis_exec(rpc_request, session_id=session_id)
 
         if tool_name == "airis-schema":
-            return await handle_airis_schema(rpc_request)
+            return await handle_airis_schema(rpc_request, session_id=session_id)
 
     # prompts/get リクエスト処理
     if rpc_request.get("method") == "prompts/get":
@@ -1142,12 +1151,13 @@ async def proxy_root_well_known(request: Request, path: str) -> Response:
     )
 
 
-async def handle_airis_find(rpc_request: Dict[str, Any]) -> Response:
+async def handle_airis_find(rpc_request: Dict[str, Any], session_id: Optional[str] = None) -> Response:
     """
     airis-find ツールコール: ツール/サーバー検索
 
     Args:
         rpc_request: JSON-RPC 2.0 リクエスト
+        session_id: SSE session ID for response routing
 
     Returns:
         JSON-RPC 2.0 レスポンス
@@ -1240,14 +1250,24 @@ async def handle_airis_find(rpc_request: Dict[str, Any]) -> Response:
 
     response_text = "\n".join(lines)
 
+    response_data = {
+        "jsonrpc": "2.0",
+        "id": rpc_request.get("id"),
+        "result": {
+            "content": [{"type": "text", "text": response_text}]
+        }
+    }
+
+    # MCP SSE Transport: Response via SSE stream
+    if session_id:
+        queue = get_response_queue(session_id)
+        await queue.put(response_data)
+        print(f"[Dynamic MCP] Queued airis-find response for session {session_id}")
+        return Response(status_code=202)
+
+    # Fallback to HTTP response if no session_id
     return Response(
-        content=json.dumps({
-            "jsonrpc": "2.0",
-            "id": rpc_request.get("id"),
-            "result": {
-                "content": [{"type": "text", "text": response_text}]
-            }
-        }),
+        content=json.dumps(response_data),
         status_code=200,
         media_type="application/json"
     )
@@ -1403,12 +1423,13 @@ async def handle_airis_exec(rpc_request: Dict[str, Any], session_id: Optional[st
         )
 
 
-async def handle_airis_schema(rpc_request: Dict[str, Any]) -> Response:
+async def handle_airis_schema(rpc_request: Dict[str, Any], session_id: Optional[str] = None) -> Response:
     """
     airis-schema ツールコール: ツールのスキーマを取得
 
     Args:
         rpc_request: JSON-RPC 2.0 リクエスト
+        session_id: SSE session ID for response routing
 
     Returns:
         JSON-RPC 2.0 レスポンス
@@ -1419,12 +1440,17 @@ async def handle_airis_schema(rpc_request: Dict[str, Any]) -> Response:
     tool_ref = arguments.get("tool")
 
     if not tool_ref:
+        error_data = {
+            "jsonrpc": "2.0",
+            "id": rpc_request.get("id"),
+            "error": {"code": -32602, "message": "tool is required"}
+        }
+        if session_id:
+            queue = get_response_queue(session_id)
+            await queue.put(error_data)
+            return Response(status_code=202)
         return Response(
-            content=json.dumps({
-                "jsonrpc": "2.0",
-                "id": rpc_request.get("id"),
-                "error": {"code": -32602, "message": "tool is required"}
-            }),
+            content=json.dumps(error_data),
             status_code=200,
             media_type="application/json"
         )
@@ -1447,15 +1473,20 @@ async def handle_airis_schema(rpc_request: Dict[str, Any]) -> Response:
             }
 
     if not schema:
+        error_data = {
+            "jsonrpc": "2.0",
+            "id": rpc_request.get("id"),
+            "error": {
+                "code": -32602,
+                "message": f"Schema not found for tool: {tool_ref}. Use airis-find to discover available tools."
+            }
+        }
+        if session_id:
+            queue = get_response_queue(session_id)
+            await queue.put(error_data)
+            return Response(status_code=202)
         return Response(
-            content=json.dumps({
-                "jsonrpc": "2.0",
-                "id": rpc_request.get("id"),
-                "error": {
-                    "code": -32602,
-                    "message": f"Schema not found for tool: {tool_ref}. Use airis-find to discover available tools."
-                }
-            }),
+            content=json.dumps(error_data),
             status_code=200,
             media_type="application/json"
         )
@@ -1474,14 +1505,24 @@ async def handle_airis_schema(rpc_request: Dict[str, Any]) -> Response:
         "```"
     ]
 
+    response_data = {
+        "jsonrpc": "2.0",
+        "id": rpc_request.get("id"),
+        "result": {
+            "content": [{"type": "text", "text": "\n".join(lines)}]
+        }
+    }
+
+    # MCP SSE Transport: Response via SSE stream
+    if session_id:
+        queue = get_response_queue(session_id)
+        await queue.put(response_data)
+        print(f"[Dynamic MCP] Queued airis-schema response for session {session_id}")
+        return Response(status_code=202)
+
+    # Fallback to HTTP response if no session_id
     return Response(
-        content=json.dumps({
-            "jsonrpc": "2.0",
-            "id": rpc_request.get("id"),
-            "result": {
-                "content": [{"type": "text", "text": "\n".join(lines)}]
-            }
-        }),
+        content=json.dumps(response_data),
         status_code=200,
         media_type="application/json"
     )

--- a/apps/api/src/app/core/dynamic_mcp.py
+++ b/apps/api/src/app/core/dynamic_mcp.py
@@ -102,6 +102,7 @@ class DynamicMCP:
                 print(f"[DynamicMCP] Failed to cache tools for {name}: {e}")
 
         # Cache Docker MCP Gateway tools
+        docker_server_tools: dict[str, int] = {}  # server_name -> tools_count
         if docker_tools:
             for tool in docker_tools:
                 tool_name = tool.get("name", "")
@@ -118,10 +119,118 @@ class DynamicMCP:
                     )
                     self._tool_to_server[tool_name] = server_name
 
+                    # Count tools per Docker server
+                    docker_server_tools[server_name] = docker_server_tools.get(server_name, 0) + 1
+
+            # Add Docker servers to server cache
+            for server_name, tools_count in docker_server_tools.items():
+                if server_name not in self._servers:
+                    self._servers[server_name] = ServerInfo(
+                        name=server_name,
+                        enabled=True,
+                        mode="docker",  # Docker servers are always running
+                        tools_count=tools_count,
+                        source="docker"
+                    )
+
         print(f"[DynamicMCP] Cached {len(self._tools)} tools from {len(self._servers)} servers")
+
+    async def refresh_cache_hot_only(
+        self,
+        process_manager,
+        docker_tools: Optional[list[dict]] = None
+    ):
+        """
+        Refresh cache with HOT servers only (fast, no cold server startup).
+
+        Cold server tools will be loaded on-demand via airis-find.
+
+        Args:
+            process_manager: ProcessManager instance
+            docker_tools: Tools from Docker MCP Gateway (optional)
+        """
+        self._tools.clear()
+        self._servers.clear()
+        self._tool_to_server.clear()
+
+        # Cache ALL server info (but only HOT server tools)
+        hot_servers = process_manager.get_hot_servers()
+        for name in process_manager.get_enabled_servers():
+            status = process_manager.get_server_status(name)
+            is_hot = name in hot_servers
+
+            self._servers[name] = ServerInfo(
+                name=name,
+                enabled=status.get("enabled", False),
+                mode="hot" if is_hot else "cold",
+                tools_count=status.get("tools_count", 0),
+                source="process"
+            )
+
+            # Only get tools from HOT servers (already running)
+            if is_hot:
+                try:
+                    tools = await process_manager._list_tools_for_server(name)
+                    for tool in tools:
+                        tool_name = tool.get("name", "")
+                        if tool_name:
+                            self._tools[tool_name] = ToolInfo(
+                                name=tool_name,
+                                server=name,
+                                description=tool.get("description", ""),
+                                input_schema=tool.get("inputSchema", {}),
+                                source="process"
+                            )
+                            self._tool_to_server[tool_name] = name
+                except Exception as e:
+                    print(f"[DynamicMCP] Failed to cache HOT tools for {name}: {e}")
+
+        # Cache Docker MCP Gateway tools
+        docker_server_tools: dict[str, int] = {}
+        if docker_tools:
+            for tool in docker_tools:
+                tool_name = tool.get("name", "")
+                if tool_name and tool_name not in self._tools:
+                    server_name = self._infer_server_name(tool_name)
+                    self._tools[tool_name] = ToolInfo(
+                        name=tool_name,
+                        server=server_name,
+                        description=tool.get("description", ""),
+                        input_schema=tool.get("inputSchema", {}),
+                        source="docker"
+                    )
+                    self._tool_to_server[tool_name] = server_name
+                    docker_server_tools[server_name] = docker_server_tools.get(server_name, 0) + 1
+
+            for server_name, tools_count in docker_server_tools.items():
+                if server_name not in self._servers:
+                    self._servers[server_name] = ServerInfo(
+                        name=server_name,
+                        enabled=True,
+                        mode="docker",
+                        tools_count=tools_count,
+                        source="docker"
+                    )
+
+        print(f"[DynamicMCP] Cached {len(self._tools)} HOT tools from {len(self._servers)} servers (COLD tools on-demand)")
 
     def _infer_server_name(self, tool_name: str) -> str:
         """Infer server name from tool name pattern."""
+        # Known Docker server tool prefixes mapping
+        # mindbase tools: conversation_, session_, memory_
+        docker_tool_prefixes = {
+            "conversation_": "mindbase",
+            "session_": "mindbase",
+            "memory_": "mindbase",
+            "get_current_time": "time",
+            "convert_time": "time",
+        }
+
+        # Check known prefixes first
+        for prefix, server in docker_tool_prefixes.items():
+            if tool_name.startswith(prefix) or tool_name == prefix.rstrip("_"):
+                return server
+
         # Common patterns: server_action, serverAction
         if "_" in tool_name:
             return tool_name.split("_")[0]


### PR DESCRIPTION
## Summary

When Claude Code initializes, `tools/list` was blocking on cold server startup (tavily: ~6.7s, playwright: ~1.8s), causing the total response time to exceed Claude Code's timeout limit (~5-10s). This resulted in Claude Code sending `notifications/cancelled` and ignoring the tool list, making the `airis-find`, `airis-exec`, and `airis-schema` meta-tools unavailable.

## Changes

- **Fast path for `tools/list`**: Return meta-tools immediately without blocking on any server operations
- **Background cache refresh**: Implement `refresh_cache_hot_only()` that only queries already-running (HOT) servers
- **SSE response routing**: Fix meta-tools handlers (`airis-find`, `airis-schema`) to properly route responses through the SSE queue instead of direct HTTP response
- **Server name inference**: Add mapping for Docker tool prefixes (mindbase: `conversation_`, `session_`, `memory_`; time: `get_current_time`, `convert_time`)

## Technical Details

The fix ensures `tools/list` responds in <100ms by:
1. Returning the 3 meta-tools immediately (no blocking)
2. Scheduling a background task to refresh the tool cache
3. Only querying HOT servers (already running) during background refresh
4. Cold servers are discovered on-demand via `airis-find`

## Test Plan

- [x] Verify `airis-find` returns results
- [x] Confirm no `notifications/cancelled` in logs during initialization
- [x] Verify `tools/list` response time < 1s
- [x] Test cold server on-demand loading via `airis-find server=<name>`

## PR Checklist

- [x] Is the change routing/proxy focused? Yes - fixes SSE response routing and tool list response timing
- [ ] Are tests included? Bug fix only, tests can be added in follow-up
- [x] Is documentation updated? N/A - no API changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)