### PR TITLE
fix(dynamic-mcp): resolve COLD server caching and routing issues

### DIFF
--- a/apps/api/src/app/core/process_runner.py
+++ b/apps/api/src/app/core/process_runner.py
@@ -587,6 +587,10 @@ class ProcessRunner:
             await asyncio.sleep(5)
 
             if self._state == ProcessState.READY:
+                # Don't kill if there are pending requests (in-flight)
+                if self._pending_requests:
+                    continue
+
                 idle_time = time.time() - self._last_used
                 # Use adaptive TTL if enabled, otherwise fall back to config
                 effective_ttl = self._current_ttl if self.config.adaptive_ttl_enabled else self.config.idle_timeout


### PR DESCRIPTION
## Context

While integrating additional ProcessManager servers (specifically COLD mode servers), I discovered several issues that prevented proper tool discovery and routing. These bugs affect any COLD server configuration, not just specific integrations.

## Problem

When COLD ProcessManager servers are enabled, the Dynamic MCP system fails to properly discover and route to them:

1. **Cache initialization gap**: COLD servers weren't added to the cache at startup (only HOT servers were cached), causing `airis-find` to miss them entirely
2. **Routing priority bug**: The routing logic checked if a server was "registered" but not if it was "enabled", causing requests to fail for disabled servers instead of falling through to Docker Gateway
3. **Race conditions**: Concurrent cache updates during tool discovery could corrupt the cache state
4. **MCP SSE protocol issue**: Startup pre-cache didn't properly implement the MCP SSE protocol (requires concurrent GET stream + POST requests)

## Changes

### `apps/api/src/app/api/endpoints/mcp_proxy.py`
- Add on-demand caching for COLD servers in `handle_airis_find`
- Fix routing priority: check both `is_process_server()` AND server in `enabled_servers`
- Ensure server cache is populated even when tools cache already exists

### `apps/api/src/app/core/dynamic_mcp.py`
- Add `refresh_cache_hot_only()` method with atomic update pattern
- Use temporary variables during cache rebuild to prevent race conditions
- Track Docker server tools_count for accurate server info

### `apps/api/src/app/main.py`
- Implement proper MCP SSE protocol for startup pre-cache
- Use concurrent GET (stream) + POST (requests) pattern as per MCP spec
- Parse endpoint event before sending initialize/tools/list requests

## Key Code Patterns

### On-demand COLD Server Caching
```python
if is_process and not server_info:
    status = process_manager.get_server_status(server)
    dynamic_mcp._servers[server] = ServerInfo(
        name=server,
        enabled=status.get("enabled", False),
        mode=status.get("mode", "cold"),
        tools_count=status.get("tools_count", 0),
        source="process"
    )
```

### Routing Priority Fix
```python
# Before (bug): only checked if registered
if process_manager.is_process_server(server_name):

# After (fix): check both registered AND enabled
enabled_servers = process_manager.get_enabled_servers()
if process_manager.is_process_server(server_name) and server_name in enabled_servers:
```

## Testing

- ✅ COLD servers now discoverable via `airis-find server=<name>`
- ✅ Routing correctly falls through to Docker Gateway for disabled servers
- ✅ No race conditions observed during concurrent tool discovery
- ✅ Startup pre-cache successfully retrieves Docker Gateway tools

## Related

This fix is independent of any specific server integration and improves the overall stability of the Dynamic MCP system.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)