### PR TITLE
fix(ci): specify pnpm version in GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 9
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 9
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

Fix the CI failure caused by missing pnpm version specification in GitHub Actions workflows.

## Problem

The `pnpm/action-setup@v4` action requires an explicit version. Without it, the action fails with:
```
Error: No pnpm version is specified.
Please specify it by one of the following ways:
  - in the GitHub Action config with the key "version"
  - in the package.json with the key "packageManager"
```

## Solution

Add `version: 9` to the pnpm setup step in both workflow files:
- `.github/workflows/ci.yml`
- `.github/workflows/release.yml`

## Files Changed

| File | Change |
|------|--------|
| `ci.yml` | Add pnpm version: 9 |
| `release.yml` | Add pnpm version: 9 |

## Note

There may be additional CI issues that will surface once this fix is applied:
- Missing `pnpm-lock.yaml` (required for `--frozen-lockfile`)
- Missing pnpm workspace configuration
- Package name mismatch with `--filter` command

These can be addressed in follow-up PRs once the immediate version error is resolved.

## Test Plan

- [x] Verify workflow syntax is valid
- [ ] CI should now progress past pnpm setup step