### PR TITLE
chore: move TAVILY_API_KEY from hardcoded to .env configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,7 @@ POSTGRES_DB=mcp_gateway
 # Encryption key for secret storage (generate for production)
 # python -c "import os, base64; print(base64.urlsafe_b64encode(os.urandom(32)).decode())"
 ENCRYPTION_MASTER_KEY=your-32-byte-base64-encoded-key-here
+
+# External API Keys (optional - for specific MCP servers)
+# Get your free API key at https://tavily.com
+# TAVILY_API_KEY=tvly-xxx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,6 +95,8 @@ services:
       # instead of all tools - reduces context token usage by ~98%
       # Set to "false" to disable and expose all tools directly
       - DYNAMIC_MCP=${DYNAMIC_MCP:-true}
+      # External API keys (optional)
+      - TAVILY_API_KEY=${TAVILY_API_KEY:-}
     volumes:
       - ./mcp-config.json:/app/mcp-config.json:ro
       - ./config/gateway-config.yaml:/app/config/gateway-config.yaml:ro

--- a/mcp-config.json
+++ b/mcp-config.json
@@ -133,9 +133,7 @@
         "mcp-remote",
         "https://mcp.tavily.com/mcp/?tavilyApiKey=${TAVILY_API_KEY}"
       ],
-      "env": {
-        "TAVILY_API_KEY": "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"
-      },
+      "env": {},
       "enabled": true,
       "mode": "cold"
     },


### PR DESCRIPTION
## Summary
- Remove hardcoded Tavily API key from `mcp-config.json`
- Add `TAVILY_API_KEY` environment variable passthrough in `docker-compose.yml`
- Document the configuration in `.env.example`

## Motivation
Hardcoding API keys in tracked files creates security risks and poor contributor experience:
- Contributors might accidentally commit their own API keys
- PR reviews require extra attention to detect key leaks
- No clear guidance on where to configure external API keys

## Changes
| File | Change |
|------|--------|
| `mcp-config.json` | Remove hardcoded `TAVILY_API_KEY` from env |
| `docker-compose.yml` | Pass `TAVILY_API_KEY` from host to container |
| `.env.example` | Add template with documentation |

## For Contributors
```bash
cp .env.example .env
# Edit .env and add your TAVILY_API_KEY
docker compose up -d
```

## Test Plan
- [x] Restart container with new configuration
- [x] Verify `TAVILY_API_KEY` passed to container
- [x] Test `airis-find server=tavily` returns 4 tools
- [x] Test `tavily_search` executes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)