### PR TITLE
feat: unified timeouts, SSE keepalive, and per-server TTL

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,53 @@ Claude Code / Cursor / Zed
 
 ## Configuration
 
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DYNAMIC_MCP` | `true` | Enable Dynamic MCP (3 meta-tools vs 60+ tools) |
+| `TOOL_CALL_TIMEOUT` | `90` | Fail-safe timeout (seconds) for MCP tool calls |
+
+#### Fail-Safe Timeout
+
+The gateway includes a configurable fail-safe timeout to prevent Claude Code from hanging indefinitely on frozen MCP tool calls:
+
+```bash
+# In docker-compose.yml or .env
+TOOL_CALL_TIMEOUT=90  # Default: 90 seconds
+```
+
+This timeout applies to both ProcessManager tool calls and Docker Gateway proxy requests.
+
+### Per-Server TTL Settings
+
+Fine-tune idle timeout behavior per server in `mcp-config.json`:
+
+```json
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["-y", "@anthropic/mcp-playwright"],
+      "enabled": true,
+      "mode": "hot",
+      "idle_timeout": 900,
+      "min_ttl": 300,
+      "max_ttl": 1800
+    }
+  }
+}
+```
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `idle_timeout` | `120` | Seconds before idle server is terminated |
+| `min_ttl` | `60` | Minimum time server stays alive after start |
+| `max_ttl` | `3600` | Maximum time server can run (hard limit) |
+
+**HOT servers** benefit from longer `idle_timeout` (e.g., 900s) to avoid cold starts.
+**COLD servers** use shorter timeouts (e.g., 300s) to free resources.
+
 ### Enable/Disable Servers
 
 Edit `mcp-config.json`:

--- a/apps/api/src/app/core/config.py
+++ b/apps/api/src/app/core/config.py
@@ -54,6 +54,11 @@ class Settings(BaseSettings):
     # instead of all available tools. This dramatically reduces context usage.
     DYNAMIC_MCP: bool = os.getenv("DYNAMIC_MCP", "false").lower() in ("true", "1", "yes")
 
+    # Tool Call Timeout (seconds)
+    # Fail-safe timeout for MCP tool calls to prevent Claude Code from hanging indefinitely.
+    # Applies to ProcessManager tool calls and Docker Gateway proxy requests.
+    TOOL_CALL_TIMEOUT: float = float(os.getenv("TOOL_CALL_TIMEOUT", "90"))
+
     # CORS
     CORS_ORIGINS: list[str] = []
 


### PR DESCRIPTION
## Summary

Unifies and improves timeout handling from PR #24 and #25:

- **TOOL_CALL_TIMEOUT**: Configurable fail-safe timeout (default: 90s) to prevent Claude Code from hanging indefinitely
- **SSE Keepalive**: Sends keepalive comments every 30s to prevent proxy connection drops
- **Per-server TTL**: Fine-tune idle_timeout, min_ttl, max_ttl per server in mcp-config.json
- **HTTP Timeout configs**: SSE_TIMEOUT, STREAM_TIMEOUT, JSONRPC timeouts with proper error handling

## Changes

| File | Change |
|------|--------|
| `config.py` | Add `TOOL_CALL_TIMEOUT` setting |
| `mcp_config_loader.py` | Parse per-server TTL settings |
| `mcp_proxy.py` | HTTP timeouts + SSE keepalive + error handling |
| `process_runner.py` | Use configurable timeout |
| `README.md` | Document new configuration options |

## New Configuration

```bash
# Environment variable
TOOL_CALL_TIMEOUT=90  # seconds
```

```json
// mcp-config.json per-server TTL
{
  "playwright": {
    "idle_timeout": 900,
    "min_ttl": 300,
    "max_ttl": 1800
  }
}
```

## Test Plan

- [x] Unit tests pass (62/62)
- [ ] E2E test with Docker

Closes #24, #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)