### PR TITLE
feat(docker): add browser automation support with VNC for MCP servers

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,11 +1,47 @@
 # FastAPI Hybrid MCP Gateway
 # Supports both Docker MCP Gateway proxy and direct uvx/npx process management
+# Includes browser automation support for Playwright and chrome-devtools MCP servers
 FROM python:3.12-slim
 
-# Install system dependencies
+# Install system dependencies including Chromium for browser automation
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     git \
+    # Chromium browser for Playwright/chrome-devtools MCP servers
+    chromium \
+    chromium-driver \
+    # Virtual framebuffer for headless browser operation
+    xvfb \
+    # VNC server for non-headless (headed) browser debugging
+    x11vnc \
+    # Lightweight window manager for VNC sessions
+    fluxbox \
+    # Web-based VNC client (access via browser at port 6080)
+    novnc \
+    websockify \
+    # Browser runtime dependencies
+    libglib2.0-0 \
+    libnss3 \
+    libnspr4 \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libcups2 \
+    libdrm2 \
+    libdbus-1-3 \
+    libxkbcommon0 \
+    libatspi2.0-0 \
+    libx11-6 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxext6 \
+    libxfixes3 \
+    libxrandr2 \
+    libgbm1 \
+    libpango-1.0-0 \
+    libcairo2 \
+    libasound2 \
+    fonts-liberation \
+    fonts-noto-color-emoji \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Node.js (for npx MCP servers)
@@ -16,8 +52,27 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
 # Install uv (for uvx MCP servers)
 RUN pip install --no-cache-dir uv
 
+# Configure browser paths for MCP servers
+ENV PLAYWRIGHT_BROWSERS_PATH=/app/.cache/ms-playwright
+ENV CHROME_PATH=/usr/bin/chromium
+
+# VNC configuration for non-headless browser debugging
+# Set BROWSER_MODE=headed to enable VNC (default: headless)
+ENV BROWSER_MODE=headless
+ENV VNC_PORT=5900
+ENV NOVNC_PORT=6080
+ENV DISPLAY=:99
+ENV VNC_RESOLUTION=1920x1080x24
+
+# Create Playwright cache directory
+RUN mkdir -p /app/.cache/ms-playwright
+
 # Verify installations
 RUN node --version && npm --version && npx --version && uvx --help || true
+RUN chromium --version || echo "Chromium installed at /usr/bin/chromium"
+
+# Pre-install Playwright Chromium (uses system chromium, installs dependencies)
+RUN npx playwright install chromium --with-deps || echo "Playwright will use system Chromium"
 
 WORKDIR /app
 
@@ -50,7 +105,50 @@ COPY config /app/config
 # Create data directory for persistent storage (memory.json, etc.)
 RUN mkdir -p /app/data
 
+# API port
 EXPOSE 8000
+# VNC port (for VNC clients like RealVNC, TightVNC)
+EXPOSE 5900
+# noVNC web port (access browser view at http://localhost:6080/vnc.html)
+EXPOSE 6080
+
+# Create startup script that handles both headless and headed modes
+RUN cat > /app/start.sh << 'STARTUP_SCRIPT'
+#!/bin/bash
+set -e
+
+if [ "$BROWSER_MODE" = "headed" ]; then
+    echo "Starting in HEADED mode with VNC support..."
+
+    # Start Xvfb (virtual framebuffer)
+    Xvfb $DISPLAY -screen 0 $VNC_RESOLUTION &
+    sleep 1
+
+    # Start fluxbox window manager
+    fluxbox -display $DISPLAY &
+    sleep 1
+
+    # Start x11vnc server (no password for local dev, add -passwd for production)
+    x11vnc -display $DISPLAY -forever -shared -rfbport $VNC_PORT &
+
+    # Start noVNC web server (access at http://localhost:6080/vnc.html)
+    /usr/share/novnc/utils/novnc_proxy --vnc localhost:$VNC_PORT --listen $NOVNC_PORT &
+
+    echo "VNC server started on port $VNC_PORT"
+    echo "noVNC web access at http://localhost:$NOVNC_PORT/vnc.html"
+else
+    echo "Starting in HEADLESS mode..."
+    # Start Xvfb for headless operation (needed by some browser tools)
+    Xvfb $DISPLAY -screen 0 $VNC_RESOLUTION &
+    sleep 1
+fi
+
+# Start the FastAPI application
+cd /app/api-src
+exec uvicorn app.main:app --host 0.0.0.0 --port 8000
+STARTUP_SCRIPT
+
+RUN chmod +x /app/start.sh
 
 # Run from api-src directory where the package is installed
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["/app/start.sh"]


### PR DESCRIPTION
## Summary

Add comprehensive browser automation support to the API Dockerfile, enabling both **headless** and **headed (VNC)** modes for Playwright and chrome-devtools MCP servers.

This PR was requested in [#30](https://github.com/agiletec-inc/airis-mcp-gateway/pull/30#issuecomment-2624000000) as a separate contribution focused on browser automation support.

## Features

### Headless Mode (default)
- Chromium browser with all runtime dependencies
- xvfb virtual framebuffer for headless operation  
- Pre-installed Playwright browsers
- Zero configuration needed

### Headed Mode (`BROWSER_MODE=headed`)
- **x11vnc** server on port 5900 for VNC clients (RealVNC, TightVNC, etc.)
- **noVNC** web interface on port 6080 (browser-based VNC - no client needed!)
- **fluxbox** lightweight window manager for desktop environment
- Visual debugging of browser automation in real-time

## Environment Variables

| Variable | Default | Description |
|----------|---------|-------------|
| `BROWSER_MODE` | `headless` | Set to `headed` for VNC support |
| `VNC_PORT` | `5900` | VNC server port |
| `NOVNC_PORT` | `6080` | noVNC web client port |
| `VNC_RESOLUTION` | `1920x1080x24` | Virtual display resolution |
| `DISPLAY` | `:99` | X display number |

## Usage

**Default (headless):**
```bash
docker compose up -d
```

**With VNC (headed):**
```bash
BROWSER_MODE=headed docker compose up -d
# Open http://localhost:6080/vnc.html in your browser
```

## Use Cases

- Web scraping and testing via Playwright MCP
- Browser debugging via chrome-devtools MCP
- **Visual debugging** of browser automation via VNC
- E2E testing automation within the gateway container
- Debugging browser-based MCP server issues

## Test Plan

- [ ] Build the Docker image successfully
- [ ] Verify headless mode works (default)
- [ ] Verify headed mode works with `BROWSER_MODE=headed`
- [ ] Access noVNC at http://localhost:6080/vnc.html
- [ ] Run Playwright MCP server and verify browser automation
- [ ] Run chrome-devtools MCP server and verify browser debugging