### PR TITLE
fix(deps): add missing cryptography dependency

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "pydantic>=2.10.0",
     "pydantic-settings>=2.6.0",
     "psutil>=5.9.0",
+    "cryptography>=42.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

Add `cryptography>=42.0.0` to `pyproject.toml` dependencies.

## Problem

The CI `test-python` job has been failing and triggering email alerts with:

```
ModuleNotFoundError: No module named 'cryptography'
```

This affects both `main` branch and all PRs.

## Root Cause

The `cryptography` package is imported in:
- `apps/api/src/app/core/encryption.py` - Fernet encryption
- `apps/api/src/app/core/crypto.py` - AESGCM

But it was missing from the `dependencies` list in `apps/api/pyproject.toml`.

## Fix

Add `cryptography>=42.0.0` to the dependencies.

## Test Plan

- [ ] CI `test-python` job passes after this fix
- [ ] All unit tests that import encryption modules can run