### PR TITLE
fix(docker): extract start.sh to fix CRLF issue on Windows

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -112,43 +112,10 @@ EXPOSE 5900
 # noVNC web port (access browser view at http://localhost:6080/vnc.html)
 EXPOSE 6080
 
-# Create startup script that handles both headless and headed modes
-RUN cat > /app/start.sh << 'STARTUP_SCRIPT'
-#!/bin/bash
-set -e
-
-if [ "$BROWSER_MODE" = "headed" ]; then
-    echo "Starting in HEADED mode with VNC support..."
-
-    # Start Xvfb (virtual framebuffer)
-    Xvfb $DISPLAY -screen 0 $VNC_RESOLUTION &
-    sleep 1
-
-    # Start fluxbox window manager
-    fluxbox -display $DISPLAY &
-    sleep 1
-
-    # Start x11vnc server (no password for local dev, add -passwd for production)
-    x11vnc -display $DISPLAY -forever -shared -rfbport $VNC_PORT &
-
-    # Start noVNC web server (access at http://localhost:6080/vnc.html)
-    /usr/share/novnc/utils/novnc_proxy --vnc localhost:$VNC_PORT --listen $NOVNC_PORT &
-
-    echo "VNC server started on port $VNC_PORT"
-    echo "noVNC web access at http://localhost:$NOVNC_PORT/vnc.html"
-else
-    echo "Starting in HEADLESS mode..."
-    # Start Xvfb for headless operation (needed by some browser tools)
-    Xvfb $DISPLAY -screen 0 $VNC_RESOLUTION &
-    sleep 1
-fi
-
-# Start the FastAPI application
-cd /app/api-src
-exec uvicorn app.main:app --host 0.0.0.0 --port 8000
-STARTUP_SCRIPT
-
-RUN chmod +x /app/start.sh
+# Copy startup script (separate file to avoid CRLF issues on Windows)
+COPY apps/api/start.sh /app/start.sh
+# Convert line endings to Unix format and make executable
+RUN sed -i 's/\r$//' /app/start.sh && chmod +x /app/start.sh
 
 # Run from api-src directory where the package is installed
 CMD ["/app/start.sh"]

--- a/apps/api/start.sh
+++ b/apps/api/start.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+if [ "$BROWSER_MODE" = "headed" ]; then
+    echo "Starting in HEADED mode with VNC support..."
+
+    # Start Xvfb (virtual framebuffer)
+    Xvfb $DISPLAY -screen 0 $VNC_RESOLUTION &
+    sleep 1
+
+    # Start fluxbox window manager
+    fluxbox -display $DISPLAY &
+    sleep 1
+
+    # Start x11vnc server (no password for local dev, add -passwd for production)
+    x11vnc -display $DISPLAY -forever -shared -rfbport $VNC_PORT &
+
+    # Start noVNC web server (access at http://localhost:6080/vnc.html)
+    /usr/share/novnc/utils/novnc_proxy --vnc localhost:$VNC_PORT --listen $NOVNC_PORT &
+
+    echo "VNC server started on port $VNC_PORT"
+    echo "noVNC web access at http://localhost:$NOVNC_PORT/vnc.html"
+else
+    echo "Starting in HEADLESS mode..."
+    # Start Xvfb for headless operation (needed by some browser tools)
+    Xvfb $DISPLAY -screen 0 $VNC_RESOLUTION &
+    sleep 1
+fi
+
+# Start the FastAPI application
+cd /app/api-src
+exec uvicorn app.main:app --host 0.0.0.0 --port 8000


### PR DESCRIPTION
## Summary
- Fix container startup failure on Windows Docker Desktop
- Extract `start.sh` from Dockerfile heredoc to separate file
- Add line ending conversion (`sed -i 's/\r$//'`) for cross-platform compatibility

## Problem
After commit 1164c3cc (browser automation support), the container fails to start on Windows with:
```
exec /app/start.sh: no such file or directory
```

This happens because heredoc in Dockerfile inherits CRLF line endings from Windows, making the shebang `#!/bin/bash\r` instead of `#!/bin/bash`.

## Solution
1. Move startup script to `apps/api/start.sh` as separate file
2. Use `COPY` instead of heredoc in Dockerfile
3. Add `sed -i 's/\r$//'` to ensure LF endings regardless of host OS

## Test plan
- [x] Rebuild image with `docker compose build --no-cache api`
- [x] Start container with `docker compose up -d`
- [x] Verify container starts and serves SSE requests