### PR TITLE
fix: resolve SSE reliability issues for mcp-remote based servers

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -115,7 +115,7 @@ RUN sed -i 's/\r$//' /app/start.sh && chmod +x /app/start.sh
 RUN useradd -m -u 1000 -s /bin/bash appuser
 
 # Create cache directories for appuser
-RUN mkdir -p /home/appuser/.cache/uv /home/appuser/.npm
+RUN mkdir -p /home/appuser/.cache/uv
 
 # Change ownership of app directories to appuser
 RUN chown -R appuser:appuser /app /home/appuser
@@ -125,6 +125,9 @@ USER appuser
 
 # Set HOME for uv/npm cache paths
 ENV HOME=/home/appuser
+
+# Use a temp-based npm cache to avoid root-owned cache from build stage
+ENV NPM_CONFIG_CACHE=/tmp/.npm-cache
 
 # API port
 EXPOSE 8000

--- a/apps/api/src/app/api/endpoints/mcp_proxy.py
+++ b/apps/api/src/app/api/endpoints/mcp_proxy.py
@@ -309,20 +309,22 @@ async def proxy_sse_stream(request: Request):
             gateway_task = None
             queue_task = None
             keepalive_task = None
+            gateway_stream_alive = True  # Track gateway stream health
 
             try:
                 while True:
                     # Start tasks if needed
-                    if gateway_task is None:
+                    if gateway_task is None and gateway_stream_alive:
                         gateway_task = asyncio.create_task(gateway_gen.__anext__())
                     if queue_task is None:
                         queue_task = asyncio.create_task(queue_gen.__anext__())
                     if keepalive_task is None:
                         keepalive_task = asyncio.create_task(keepalive_gen.__anext__())
 
-                    # Wait for any to complete
+                    # Wait for any to complete (only include active tasks)
+                    tasks_to_wait = [t for t in [gateway_task, queue_task, keepalive_task] if t is not None]
                     done, _ = await asyncio.wait(
-                        [gateway_task, queue_task, keepalive_task],
+                        tasks_to_wait,
                         return_when=asyncio.FIRST_COMPLETED
                     )
 
@@ -330,23 +332,47 @@ async def proxy_sse_stream(request: Request):
                         try:
                             source, data = task.result()
                         except StopAsyncIteration:
-                            # Gateway stream ended
+                            if task is gateway_task:
+                                # Gateway stream ended — continue serving process manager responses
+                                logger.info(f"Gateway SSE stream ended, continuing with process manager (session={captured_session_id})")
+                                gateway_task = None
+                                gateway_stream_alive = False
+                                continue
+                            # Queue or keepalive generator ended (shouldn't happen)
                             if captured_session_id:
                                 await remove_response_queue(captured_session_id)
                             return
                         except (httpx.ReadError, httpx.RemoteProtocolError, httpx.ConnectError) as e:
+                            if task is gateway_task:
+                                # Gateway connection lost — continue with process manager
+                                logger.info(f"Gateway disconnected ({type(e).__name__}), continuing with process manager (session={captured_session_id})")
+                                gateway_task = None
+                                gateway_stream_alive = False
+                                continue
                             # Client disconnected - this is normal, exit gracefully
                             logger.info(f"Client disconnected: {type(e).__name__}")
                             if captured_session_id:
                                 await remove_response_queue(captured_session_id)
                             return
                         except httpx.ReadTimeout:
-                            # SSE read timeout - connection may be stale
+                            if task is gateway_task:
+                                # Gateway idle timeout — continue serving process manager responses
+                                # This is expected when only process manager tools are being used
+                                logger.info(f"Gateway SSE idle timeout, continuing with process manager (session={captured_session_id})")
+                                gateway_task = None
+                                gateway_stream_alive = False
+                                continue
+                            # Non-gateway timeout - clean up
                             logger.info(f"SSE read timeout (session={captured_session_id})")
                             if captured_session_id:
                                 await remove_response_queue(captured_session_id)
                             return
                         except httpx.TimeoutException as e:
+                            if task is gateway_task:
+                                logger.info(f"Gateway timeout ({type(e).__name__}), continuing with process manager (session={captured_session_id})")
+                                gateway_task = None
+                                gateway_stream_alive = False
+                                continue
                             # Other timeout (connect, pool, etc.)
                             logger.info(f"Timeout exception: {type(e).__name__}")
                             if captured_session_id:
@@ -367,7 +393,7 @@ async def proxy_sse_stream(request: Request):
                             # ProcessManager からのレスポンスを SSE で送信
                             queue_task = None
                             logger.info(f"Sending ProcessManager response via SSE: id={data.get('id') if isinstance(data, dict) else None}")
-                            yield f"data: {json.dumps(data)}\n\n"
+                            yield f"event: message\ndata: {json.dumps(data)}\n\n"
                             continue
 
                         # Gateway からのメッセージ
@@ -1459,6 +1485,12 @@ async def handle_airis_exec(rpc_request: Dict[str, Any], session_id: Optional[st
 
     tool_ref = arguments.get("tool")
     tool_args = arguments.get("arguments", {})
+    # Handle string-encoded JSON arguments (Claude Code may send "{}" instead of {})
+    if isinstance(tool_args, str):
+        try:
+            tool_args = json.loads(tool_args)
+        except (json.JSONDecodeError, TypeError):
+            tool_args = {}
 
     if not tool_ref:
         return Response(

--- a/apps/api/src/app/core/process_runner.py
+++ b/apps/api/src/app/core/process_runner.py
@@ -343,7 +343,11 @@ class ProcessRunner:
             "params": {}
         }
 
-        response = await self._send_request(request, timeout=10.0)
+        try:
+            response = await self._send_request(request, timeout=10.0)
+        except Exception as e:
+            logger.error(f"{self.config.name} tools/list failed: {e}")
+            raise
 
         if "result" in response:
             self._tools = response["result"].get("tools", [])
@@ -396,7 +400,16 @@ class ProcessRunner:
             }
         }
 
-        return await self._send_request(request, timeout=30.0)
+        try:
+            return await self._send_request(request, timeout=30.0)
+        except Exception as e:
+            return {
+                "jsonrpc": "2.0",
+                "error": {
+                    "code": -32603,
+                    "message": f"prompts/get failed: {e}"
+                }
+            }
 
     async def call_tool(self, tool_name: str, arguments: dict[str, Any], max_retries: int = 2) -> dict[str, Any]:
         """
@@ -447,19 +460,15 @@ class ProcessRunner:
                 self._total_calls += 1
                 self._record_call()  # For adaptive TTL
 
-                # Check for process crash during call
-                if "error" in result:
-                    error_code = result.get("error", {}).get("code", 0)
-                    # Internal error or timeout - might be process crash
-                    if error_code in [-32603, -32000] and attempt < max_retries:
-                        last_error = result.get("error", {}).get("message", "Unknown error")
-                        logger.warning(f"{self.config.name} retry {attempt + 1}/{max_retries}: {last_error}")
-                        await self._restart_process()
-                        continue
-
+                # If _send_request returned (didn't raise), the subprocess responded
+                # via STDIO. Even if the response contains an error, the process is
+                # healthy — the error came from the remote server (e.g. mcp-remote
+                # forwarding a business error). Do NOT restart the process.
                 return result
 
             except asyncio.TimeoutError:
+                # No response from subprocess within timeout — likely process crash
+                # or hang. Restart and retry.
                 last_error = f"Request timeout after {settings.TOOL_CALL_TIMEOUT}s"
                 if attempt < max_retries:
                     logger.warning(f"{self.config.name} retry {attempt + 1}/{max_retries}: timeout, restarting")
@@ -474,6 +483,7 @@ class ProcessRunner:
                 }
 
             except Exception as e:
+                # STDIO write failed, process not running, etc. — restart and retry.
                 last_error = str(e)
                 if attempt < max_retries:
                     logger.warning(f"{self.config.name} retry {attempt + 1}/{max_retries}: {e}")
@@ -519,14 +529,33 @@ class ProcessRunner:
         if "id" not in request:
             request = {**request, "id": self._next_id()}
 
-        return await self._send_request(request, timeout=settings.TOOL_CALL_TIMEOUT)
+        try:
+            return await self._send_request(request, timeout=settings.TOOL_CALL_TIMEOUT)
+        except Exception as e:
+            return {
+                "jsonrpc": "2.0",
+                "id": request.get("id"),
+                "error": {
+                    "code": -32603,
+                    "message": str(e)
+                }
+            }
 
     def _next_id(self) -> int:
         self._request_id += 1
         return self._request_id
 
     async def _send_request(self, request: dict[str, Any], timeout: float = 30.0) -> dict[str, Any]:
-        """Send a request and wait for response."""
+        """
+        Send a request and wait for response.
+
+        Returns the subprocess response dict on success.
+        Raises asyncio.TimeoutError if no response within timeout.
+        Raises RuntimeError/Exception on connection/process errors.
+
+        Callers can use exceptions to distinguish local failures (process crash,
+        timeout) from remote errors forwarded by the subprocess.
+        """
         if not self._proc or not self._proc.stdin:
             raise RuntimeError("Process not running")
 
@@ -548,26 +577,9 @@ class ProcessRunner:
             # Wait for response
             return await asyncio.wait_for(future, timeout=timeout)
 
-        except asyncio.TimeoutError:
+        except BaseException:
             self._pending_requests.pop(request_id, None)
-            return {
-                "jsonrpc": "2.0",
-                "id": request_id,
-                "error": {
-                    "code": -32603,
-                    "message": f"Request timeout after {timeout}s"
-                }
-            }
-        except Exception as e:
-            self._pending_requests.pop(request_id, None)
-            return {
-                "jsonrpc": "2.0",
-                "id": request_id,
-                "error": {
-                    "code": -32603,
-                    "message": str(e)
-                }
-            }
+            raise
 
     async def _send_notification(self, notification: dict[str, Any]):
         """Send a notification (no response expected)."""

--- a/apps/api/tests/unit/test_retry_logic.py
+++ b/apps/api/tests/unit/test_retry_logic.py
@@ -77,23 +77,30 @@ class TestProcessRunnerRetry:
         runner._restart_process.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_retry_on_internal_error(self, runner):
-        """Should retry on internal error (-32603)."""
+    async def test_no_retry_on_remote_internal_error(self, runner):
+        """Should NOT retry on remote -32603 errors (subprocess responded normally).
+
+        When _send_request returns (doesn't raise), it means the subprocess
+        responded via STDIO. Even if the response contains a -32603 error,
+        the process is healthy — the error was forwarded from a remote server
+        (e.g. mcp-remote proxying a business error). No restart needed.
+        """
         runner.ensure_ready = AsyncMock(return_value=True)
         runner._restart_process = AsyncMock()
-        # First call returns error, second succeeds
-        runner._send_request = AsyncMock(side_effect=[
-            {"jsonrpc": "2.0", "error": {"code": -32603, "message": "Internal error"}},
-            {"jsonrpc": "2.0", "id": 1, "result": {"success": True}}
-        ])
+        # Remote error forwarded through mcp-remote as -32603
+        runner._send_request = AsyncMock(return_value={
+            "jsonrpc": "2.0",
+            "error": {"code": -32603, "message": "An error occurred"}
+        })
 
         with patch('app.core.process_runner.settings') as mock_settings:
             mock_settings.TOOL_CALL_TIMEOUT = 10.0
             result = await runner.call_tool("test_tool", {}, max_retries=2)
 
-        assert "result" in result
-        assert runner._send_request.call_count == 2
-        runner._restart_process.assert_called_once()
+        assert "error" in result
+        assert result["error"]["code"] == -32603
+        runner._send_request.assert_called_once()  # No retry
+        runner._restart_process.assert_not_called()  # No restart
 
     @pytest.mark.asyncio
     async def test_no_retry_on_application_error(self, runner):
@@ -136,6 +143,43 @@ class TestProcessRunnerRetry:
         # First call raises exception, second succeeds
         runner._send_request = AsyncMock(side_effect=[
             Exception("Connection lost"),
+            {"jsonrpc": "2.0", "id": 1, "result": {"success": True}}
+        ])
+
+        with patch('app.core.process_runner.settings') as mock_settings:
+            mock_settings.TOOL_CALL_TIMEOUT = 10.0
+            result = await runner.call_tool("test_tool", {}, max_retries=2)
+
+        assert "result" in result
+        assert runner._send_request.call_count == 2
+        runner._restart_process.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_no_retry_on_remote_server_error(self, runner):
+        """Should NOT retry on -32000 errors from remote servers."""
+        runner.ensure_ready = AsyncMock(return_value=True)
+        runner._restart_process = AsyncMock()
+        runner._send_request = AsyncMock(return_value={
+            "jsonrpc": "2.0",
+            "error": {"code": -32000, "message": "Server error from remote"}
+        })
+
+        with patch('app.core.process_runner.settings') as mock_settings:
+            mock_settings.TOOL_CALL_TIMEOUT = 10.0
+            result = await runner.call_tool("test_tool", {}, max_retries=2)
+
+        assert "error" in result
+        runner._send_request.assert_called_once()
+        runner._restart_process.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_retry_on_process_crash_exception(self, runner):
+        """Should retry when _send_request raises (process crash/STDIO failure)."""
+        runner.ensure_ready = AsyncMock(return_value=True)
+        runner._restart_process = AsyncMock()
+        # First call: process crashes (raises), second call: succeeds
+        runner._send_request = AsyncMock(side_effect=[
+            RuntimeError("Process not running"),
             {"jsonrpc": "2.0", "id": 1, "result": {"success": True}}
         ])
 


### PR DESCRIPTION
## Summary

Four interconnected bugs prevented mcp-remote based MCP servers (sorftime, brightdata, serpapi) from working through the SSE transport.

### Bug 1: Dockerfile npm cache permission (EACCES)
- Build-stage `npm install` runs as root, creating cache owned by root at `/home/appuser/.npm`
- Runtime `appuser` couldn't write to root-owned cache → all `npx` commands failed
- **Fix:** Set `NPM_CONFIG_CACHE=/tmp/.npm-cache` to bypass build-stage artifacts

### Bug 2: Retry logic misidentifying remote errors as process crashes
- `ProcessRunner.call_tool()` treated all `-32603` JSON-RPC errors as process crashes
- `mcp-remote` forwards remote server business errors via STDIO as `-32603`
- This triggered unnecessary restart+retry cycles (3× cold start penalty)
- **Fix:** Only restart on exceptions (actual STDIO pipe failures), not on error responses from healthy processes

### Bug 3: SSE connection terminated by Docker Gateway idle timeout
- Gateway SSE stream at port 9390 times out after ~120s of inactivity
- Exception handler called `return`, terminating the **entire** SSE connection
- All ProcessManager responses queued for delivery were silently lost
- **Fix:** Graceful degradation — mark gateway stream as dead, continue serving ProcessManager responses and keepalives

### Bug 4: String-encoded JSON arguments in airis-exec
- Claude Code sends `"arguments": "{...}"` (string) instead of `"arguments": {...}` (object)
- Remote MCP servers received malformed arguments and returned errors
- **Fix:** Parse string arguments with `json.loads()` before forwarding

## Files Changed
- `apps/api/Dockerfile` — npm cache path fix
- `apps/api/src/app/core/process_runner.py` — retry logic: exceptions-only restart
- `apps/api/src/app/api/endpoints/mcp_proxy.py` — SSE graceful degradation + string args parsing
- `apps/api/tests/unit/test_retry_logic.py` — updated tests for new retry semantics

## Test Plan
- [x] `npx --version` works inside container (Bug 1)
- [x] No unnecessary process restarts on remote server errors (Bug 2)
- [x] SSE connection survives Docker Gateway timeout (Bug 3)
- [x] `airis-exec` with string-encoded arguments returns data (Bug 4)
- [x] End-to-end: `sorftime:ali1688_similar_product` returns 50 products via SSE
- [ ] Unit tests pass: `pytest tests/unit/test_retry_logic.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)