### PR TITLE
feat(api): add airis-route meta-tool and routing engine

### DIFF
--- a/apps/api/src/app/api/endpoints/mcp_proxy.py
+++ b/apps/api/src/app/api/endpoints/mcp_proxy.py
@@ -15,6 +15,7 @@ from ...core.config import settings
 from ...core.protocol_logger import protocol_logger
 from ...core.process_manager import get_process_manager
 from ...core.dynamic_mcp import get_dynamic_mcp
+from ...core.routing_engine import format_routing_table_as_instructions
 from ...core.logging import get_logger
 from ...core.mcp_config_loader import ServerMode
 
@@ -478,6 +479,10 @@ async def proxy_sse_stream(request: Request):
                                         "When you need a capability (web search, memory, code analysis, etc.), "
                                         "ALWAYS start with airis-find or airis-suggest to discover available tools."
                                     )
+                                    # Append routing table hints if available
+                                    routing_instructions = format_routing_table_as_instructions()
+                                    if routing_instructions:
+                                        json_data["result"]["instructions"] += "\n\n" + routing_instructions
 
                                 # 変換後のデータを返す
                                 yield f"data: {json.dumps(json_data)}\n\n"
@@ -1111,6 +1116,9 @@ async def _proxy_jsonrpc_request(request: Request) -> Response:
 
         if tool_name == "airis-suggest":
             return await handle_airis_suggest(rpc_request, session_id=session_id)
+
+        if tool_name == "airis-route":
+            return await handle_airis_route(rpc_request, session_id=session_id)
 
     # prompts/get リクエスト処理
     if rpc_request.get("method") == "prompts/get":
@@ -2093,6 +2101,81 @@ async def handle_airis_suggest(rpc_request: Dict[str, Any], session_id: Optional
         queue = await get_response_queue(session_id)
         await queue.put(response_data)
         logger.info(f"Queued airis-suggest response for session {session_id}")
+        return Response(status_code=202)
+
+    return Response(
+        content=json.dumps(response_data),
+        status_code=200,
+        media_type="application/json"
+    )
+
+
+async def handle_airis_route(rpc_request: Dict[str, Any], session_id: Optional[str] = None) -> Response:
+    """
+    airis-route: Route a task to the optimal tool chain.
+
+    Args:
+        rpc_request: JSON-RPC 2.0 request
+        session_id: SSE session ID for response routing
+
+    Returns:
+        JSON-RPC 2.0 response
+    """
+    from ...core.routing_engine import load_routing_table, route_task
+
+    params = rpc_request.get("params", {}).get("arguments", {})
+    task = params.get("task", "")
+    max_results = params.get("max_results", 5)
+
+    if not task:
+        response_data = {
+            "jsonrpc": "2.0",
+            "id": rpc_request.get("id"),
+            "error": {"code": -32602, "message": "Missing required parameter: task"}
+        }
+    else:
+        dynamic_mcp = get_dynamic_mcp()
+        routing_table = load_routing_table()
+        result = route_task(
+            task=task,
+            routing_table=routing_table,
+            dynamic_mcp=dynamic_mcp,
+            max_results=max_results,
+        )
+
+        # Format as readable text
+        lines = []
+        if result.chain:
+            lines.append(f"## Route: {result.hint}")
+            lines.append(f"Chain: {' → '.join(result.chain)}")
+            lines.append(f"Pattern: `{result.pattern}`")
+        else:
+            lines.append("## No direct route found")
+            lines.append("Falling back to tool suggestions.")
+
+        if result.suggestions:
+            lines.append("")
+            lines.append("## Suggested Tools")
+            for i, s in enumerate(result.suggestions, 1):
+                score_pct = int(s["score"] * 100)
+                lines.append(f"{i}. **{s['server']}:{s['tool']}** ({score_pct}%) — {s['reason']}")
+
+        lines.append("")
+        lines.append("Use `airis-exec` to execute tools in the chain.")
+
+        response_data = {
+            "jsonrpc": "2.0",
+            "id": rpc_request.get("id"),
+            "result": {
+                "content": [{"type": "text", "text": "\n".join(lines)}]
+            }
+        }
+
+    # MCP SSE Transport: Response via SSE stream
+    if session_id:
+        queue = await get_response_queue(session_id)
+        await queue.put(response_data)
+        logger.info(f"Queued airis-route response for session {session_id}")
         return Response(status_code=202)
 
     return Response(

--- a/apps/api/src/app/core/dynamic_mcp.py
+++ b/apps/api/src/app/core/dynamic_mcp.py
@@ -572,6 +572,24 @@ class DynamicMCP:
                     },
                     "required": ["intent"]
                 }
+            },
+            {
+                "name": "airis-route",
+                "description": "Route a task to the optimal tool chain. Matches task against known patterns and returns the recommended tool execution order. Faster than airis-find for common workflows.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "task": {
+                            "type": "string",
+                            "description": "Natural language task description. Examples: 'research best practices for React hooks', 'query user table in database', 'create a Stripe invoice'"
+                        },
+                        "max_results": {
+                            "type": "integer",
+                            "description": "Maximum number of additional suggestions to return (default: 5)"
+                        }
+                    },
+                    "required": ["task"]
+                }
             }
         ]
 

--- a/apps/api/src/app/core/routing_engine.py
+++ b/apps/api/src/app/core/routing_engine.py
@@ -1,0 +1,176 @@
+"""Routing engine for proactive tool orchestration.
+
+Matches task descriptions against routing-table.json patterns
+and enriches results with airis-suggest scores.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+from .logging import get_logger
+from .tool_suggester import SuggestToolRequest, suggest_tool
+
+if TYPE_CHECKING:
+    from .dynamic_mcp import DynamicMCP
+
+logger = get_logger(__name__)
+
+# Default path inside Docker container
+DEFAULT_ROUTING_TABLE_PATH = "/app/routing-table.json"
+
+# Module-level cache
+_routing_table: Optional[Dict[str, Any]] = None
+_routing_table_path: Optional[str] = None
+
+
+@dataclass
+class RouteResult:
+    """Result of routing a task to tool chains.
+
+    Attributes:
+        chain: Matched tool chain from routing table
+        hint: Human-readable hint for the route
+        suggestions: Additional tool suggestions from airis-suggest
+        pattern: The regex pattern that matched
+    """
+
+    chain: List[str]
+    hint: str
+    suggestions: List[Dict[str, Any]] = field(default_factory=list)
+    pattern: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "chain": self.chain,
+            "hint": self.hint,
+            "suggestions": self.suggestions,
+            "pattern": self.pattern,
+        }
+
+
+def load_routing_table(path: str = DEFAULT_ROUTING_TABLE_PATH) -> Dict[str, Any]:
+    """Load routing table from JSON file with caching.
+
+    Args:
+        path: Path to routing-table.json
+
+    Returns:
+        Parsed routing table dict, or empty dict if not found
+    """
+    global _routing_table, _routing_table_path
+
+    # Return cached if same path
+    if _routing_table is not None and _routing_table_path == path:
+        return _routing_table
+
+    try:
+        with open(path) as f:
+            _routing_table = json.load(f)
+            _routing_table_path = path
+            logger.info(f"Loaded routing table from {path} ({len(_routing_table.get('routes', []))} routes)")
+            return _routing_table
+    except FileNotFoundError:
+        logger.debug(f"Routing table not found at {path}, returning empty")
+        return {}
+    except json.JSONDecodeError as e:
+        logger.error(f"Invalid JSON in routing table {path}: {e}")
+        return {}
+
+
+def format_routing_table_as_instructions(path: str = DEFAULT_ROUTING_TABLE_PATH) -> str:
+    """Format routing table as compact instructions text for MCP initialize response.
+
+    Args:
+        path: Path to routing-table.json
+
+    Returns:
+        Formatted instructions string, or empty string if not available
+    """
+    table = load_routing_table(path)
+    if not table or "routes" not in table:
+        return ""
+
+    routes = table["routes"]
+    parts = []
+    for route in routes:
+        hint = route.get("hint", "")
+        chain = route.get("chain", [])
+        chain_str = " → ".join(chain)
+        parts.append(f"{hint}: {chain_str}")
+
+    return "## Quick Routes\n" + " | ".join(parts)
+
+
+def route_task(
+    task: str,
+    routing_table: Optional[Dict[str, Any]] = None,
+    dynamic_mcp: Optional["DynamicMCP"] = None,
+    max_results: int = 5,
+) -> RouteResult:
+    """Route a task description to optimal tool chains.
+
+    Matches task against routing-table patterns (regex), then
+    enriches with airis-suggest scores from tool_suggester.
+
+    Args:
+        task: Natural language task description
+        routing_table: Pre-loaded routing table (loads from default path if None)
+        dynamic_mcp: DynamicMCP instance for suggestion enrichment
+        max_results: Maximum suggestions to include
+
+    Returns:
+        RouteResult with matched chain, hint, and suggestions
+    """
+    if routing_table is None:
+        routing_table = load_routing_table()
+
+    # Match against routing table patterns
+    matched_chain: List[str] = []
+    matched_hint = ""
+    matched_pattern = ""
+
+    task_lower = task.lower()
+    routes = routing_table.get("routes", [])
+
+    for route in routes:
+        pattern = route.get("pattern", "")
+        if not pattern:
+            continue
+        try:
+            if re.search(pattern, task_lower):
+                matched_chain = route.get("chain", [])
+                matched_hint = route.get("hint", "")
+                matched_pattern = pattern
+                break
+        except re.error as e:
+            logger.warning(f"Invalid regex in routing table: {pattern}: {e}")
+            continue
+
+    # Enrich with airis-suggest
+    suggestions: List[Dict[str, Any]] = []
+    try:
+        request = SuggestToolRequest(intent=task, max_results=max_results)
+        response = suggest_tool(request, dynamic_mcp=dynamic_mcp)
+        suggestions = [s.to_dict() for s in response.suggestions]
+    except Exception as e:
+        logger.warning(f"Failed to get suggestions for route: {e}")
+
+    return RouteResult(
+        chain=matched_chain,
+        hint=matched_hint,
+        suggestions=suggestions,
+        pattern=matched_pattern,
+    )
+
+
+def invalidate_cache() -> None:
+    """Invalidate the routing table cache (useful for testing or hot-reload)."""
+    global _routing_table, _routing_table_path
+    _routing_table = None
+    _routing_table_path = None

--- a/apps/api/tests/unit/test_dynamic_mcp.py
+++ b/apps/api/tests/unit/test_dynamic_mcp.py
@@ -190,11 +190,15 @@ class TestDynamicMCPMetaTools:
         """Test getting meta-tool definitions"""
         tools = dynamic_mcp.get_meta_tools()
 
-        assert len(tools) == 3
+        assert len(tools) == 7
         tool_names = [t["name"] for t in tools]
         assert "airis-find" in tool_names
         assert "airis-exec" in tool_names
         assert "airis-schema" in tool_names
+        assert "airis-confidence" in tool_names
+        assert "airis-repo-index" in tool_names
+        assert "airis-suggest" in tool_names
+        assert "airis-route" in tool_names
 
     def test_meta_tools_have_schemas(self, dynamic_mcp):
         """Test that meta-tools have valid input schemas"""
@@ -359,12 +363,12 @@ class TestDynamicMCPModeWithHotTools:
         return mcp
 
     def test_meta_tools_count(self, dynamic_mcp):
-        """Meta-tools should be exactly 3: airis-find, airis-exec, airis-schema."""
+        """Meta-tools should include all 7 meta-tools."""
         meta_tools = dynamic_mcp.get_meta_tools()
 
-        assert len(meta_tools) == 3
+        assert len(meta_tools) == 7
         names = {t["name"] for t in meta_tools}
-        assert names == {"airis-find", "airis-exec", "airis-schema"}
+        assert names == {"airis-find", "airis-exec", "airis-schema", "airis-confidence", "airis-repo-index", "airis-suggest", "airis-route"}
 
     def test_hot_server_tools_separate_from_cold(self, mcp_with_hot_and_cold):
         """HOT and COLD server tools should be properly categorized."""
@@ -393,12 +397,12 @@ class TestDynamicMCPModeWithHotTools:
         # All tools (HOT and COLD) are accessed via airis-exec
         dynamic_tools = list(meta_tools)
 
-        # Expected: 3 meta-tools ONLY
-        assert len(dynamic_tools) == 3
+        # Expected: 7 meta-tools ONLY
+        assert len(dynamic_tools) == 7
 
         # Verify ONLY meta-tools are present
         tool_names = {t["name"] for t in dynamic_tools}
-        assert tool_names == {"airis-find", "airis-exec", "airis-schema"}
+        assert tool_names == {"airis-find", "airis-exec", "airis-schema", "airis-confidence", "airis-repo-index", "airis-suggest", "airis-route"}
 
         # Verify HOT tools are NOT directly exposed
         assert "gateway_list_servers" not in tool_names
@@ -443,18 +447,18 @@ class TestDynamicMCPModeWithHotTools:
 
         # Dynamic mode: meta-tools ONLY (no HOT tools exposed directly)
         meta_tools = mcp.get_meta_tools()
-        dynamic_tools_count = len(meta_tools)  # 3 tools only
+        dynamic_tools_count = len(meta_tools)  # 7 meta-tools only
 
         # Token estimate (300 tokens per tool schema)
         full_mode_tokens = all_tools_count * 300  # 31,500 tokens
-        dynamic_mode_tokens = dynamic_tools_count * 300  # 900 tokens
+        dynamic_mode_tokens = dynamic_tools_count * 300  # 2,100 tokens
 
         # Calculate savings
         savings_percent = (1 - dynamic_mode_tokens / full_mode_tokens) * 100
 
-        # Should have significant savings (> 97% with meta-tools only)
-        assert savings_percent > 97, \
-            f"Expected >97% savings, got {savings_percent:.1f}%"
+        # Should have significant savings (> 90% with meta-tools only)
+        assert savings_percent > 90, \
+            f"Expected >90% savings, got {savings_percent:.1f}%"
 
         print(f"Token savings: {savings_percent:.1f}% "
               f"({full_mode_tokens:,} -> {dynamic_mode_tokens:,} tokens)")

--- a/apps/api/tests/unit/test_routing_engine.py
+++ b/apps/api/tests/unit/test_routing_engine.py
@@ -1,0 +1,129 @@
+"""Tests for routing_engine module."""
+
+import json
+import pytest
+from unittest.mock import patch, mock_open
+
+from app.core.routing_engine import (
+    load_routing_table,
+    format_routing_table_as_instructions,
+    route_task,
+    RouteResult,
+    invalidate_cache,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    """Clear routing table cache before each test."""
+    invalidate_cache()
+    yield
+    invalidate_cache()
+
+
+SAMPLE_TABLE = {
+    "routes": [
+        {"pattern": "research|investigate|search web", "chain": ["tavily:search"], "hint": "Web research"},
+        {"pattern": "database|sql|query", "chain": ["supabase:query"], "hint": "Database"},
+        {"pattern": "payment|invoice|billing", "chain": ["stripe:*"], "hint": "Payments"},
+    ]
+}
+
+
+class TestLoadRoutingTable:
+    """Test load_routing_table function."""
+
+    def test_file_not_found(self):
+        """Returns empty dict when file doesn't exist."""
+        result = load_routing_table("/nonexistent/path.json")
+        assert result == {}
+
+    def test_valid_json(self, tmp_path):
+        """Loads and caches valid JSON."""
+        f = tmp_path / "routing-table.json"
+        f.write_text(json.dumps(SAMPLE_TABLE))
+        result = load_routing_table(str(f))
+        assert len(result["routes"]) == 3
+
+    def test_invalid_json(self, tmp_path):
+        """Returns empty dict for invalid JSON."""
+        f = tmp_path / "bad.json"
+        f.write_text("not json{")
+        result = load_routing_table(str(f))
+        assert result == {}
+
+    def test_caching(self, tmp_path):
+        """Returns cached result on second call."""
+        f = tmp_path / "routing-table.json"
+        f.write_text(json.dumps(SAMPLE_TABLE))
+        path = str(f)
+        result1 = load_routing_table(path)
+        # Modify file - should still return cached
+        f.write_text(json.dumps({"routes": []}))
+        result2 = load_routing_table(path)
+        assert result1 is result2
+
+
+class TestFormatRoutingTableAsInstructions:
+    """Test format_routing_table_as_instructions function."""
+
+    def test_with_routes(self, tmp_path):
+        """Formats routes as compact instruction text."""
+        f = tmp_path / "routing-table.json"
+        f.write_text(json.dumps(SAMPLE_TABLE))
+        result = format_routing_table_as_instructions(str(f))
+        assert "## Quick Routes" in result
+        assert "Web research: tavily:search" in result
+        assert "Database: supabase:query" in result
+
+    def test_empty_table(self):
+        """Returns empty string when no file exists."""
+        result = format_routing_table_as_instructions("/nonexistent/path.json")
+        assert result == ""
+
+
+class TestRouteTask:
+    """Test route_task function."""
+
+    def test_matches_pattern(self):
+        """Matches task against routing table patterns."""
+        result = route_task("research best practices for React", routing_table=SAMPLE_TABLE)
+        assert result.chain == ["tavily:search"]
+        assert result.hint == "Web research"
+
+    def test_database_pattern(self):
+        """Matches database-related tasks."""
+        result = route_task("query the users table", routing_table=SAMPLE_TABLE)
+        assert result.chain == ["supabase:query"]
+        assert result.hint == "Database"
+
+    def test_no_match(self):
+        """Returns empty chain when no pattern matches."""
+        result = route_task("deploy to production", routing_table=SAMPLE_TABLE)
+        assert result.chain == []
+        assert result.hint == ""
+
+    def test_empty_routing_table(self):
+        """Handles empty routing table gracefully."""
+        result = route_task("research something", routing_table={})
+        assert result.chain == []
+
+    def test_suggestions_included(self):
+        """Includes tool suggestions even without route match."""
+        result = route_task("create a stripe invoice", routing_table=SAMPLE_TABLE)
+        # Should match "invoice" pattern and also get suggestions
+        assert result.chain == ["stripe:*"]
+        assert isinstance(result.suggestions, list)
+
+    def test_result_to_dict(self):
+        """RouteResult serializes correctly."""
+        result = RouteResult(
+            chain=["tavily:search"],
+            hint="Web research",
+            suggestions=[{"server": "tavily", "tool": "search", "score": 0.8, "reason": "test"}],
+            pattern="research",
+        )
+        d = result.to_dict()
+        assert d["chain"] == ["tavily:search"]
+        assert d["hint"] == "Web research"
+        assert len(d["suggestions"]) == 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,6 +101,7 @@ services:
       - TAVILY_API_KEY=${TAVILY_API_KEY:-}
     volumes:
       - ./mcp-config.json:/app/mcp-config.json:ro
+      - ./routing-table.json:/app/routing-table.json:ro
       - ./config/gateway-config.yaml:/app/config/gateway-config.yaml:ro
       - ./profiles:/app/profiles:rw
       # Persistent data volumes (appuser home directory)

--- a/routing-table.json
+++ b/routing-table.json
@@ -1,0 +1,10 @@
+{ "routes": [
+  {"pattern": "research|investigate|search web", "chain": ["tavily:search"], "hint": "Web research"},
+  {"pattern": "implement|build|code", "chain": ["airis-confidence","context7:get-library-docs"], "hint": "Implementation"},
+  {"pattern": "database|sql|query", "chain": ["supabase:query"], "hint": "Database"},
+  {"pattern": "payment|invoice|billing", "chain": ["stripe:*"], "hint": "Payments"},
+  {"pattern": "memory|remember|recall", "chain": ["memory:*"], "hint": "Knowledge graph"},
+  {"pattern": "browse|screenshot|web page", "chain": ["playwright:*"], "hint": "Browser automation"},
+  {"pattern": "code analysis|symbol|codebase", "chain": ["serena:*"], "hint": "Code intelligence"},
+  {"pattern": "docs|documentation|reference", "chain": ["context7:resolve-library-id","context7:get-library-docs"], "hint": "Official docs"}
+]}


### PR DESCRIPTION
## Summary
- `routing-table.json` でパターンベースのツールチェーンマッピングを定義
- `routing_engine.py` でタスク→最適ツールチェーンのマッチング + airis-suggest スコアで補完
- 7番目のメタツール `airis-route` を追加（airis-find をスキップして直接ルーティング）
- Gateway initialize レスポンスに Quick Routes ヒントを自動追加

## Test plan
- [x] `test_routing_engine.py` 12テスト通過
- [x] `test_dynamic_mcp.py` メタツール数を7に更新、全テスト通過
- [x] 全381ユニットテスト通過
- [x] `docker compose up -d` で正常起動確認
- [x] `routing-table.json` がコンテナ内に正しくマウントされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)