### PR TITLE
feat(api): improve Dynamic MCP tool discovery for COLD/disabled servers

### DIFF
--- a/apps/api/src/app/api/endpoints/mcp_proxy.py
+++ b/apps/api/src/app/api/endpoints/mcp_proxy.py
@@ -1356,10 +1356,13 @@ async def handle_airis_find(rpc_request: Dict[str, Any], session_id: Optional[st
 
     # Always ensure servers are cached (even if tools already exist)
     # This is needed because tools/list populates tools but not necessarily servers
-    if not dynamic_mcp._servers:
+    # Check for process servers specifically (Docker servers may already be pre-cached)
+    has_process_servers = any(s.source == "process" for s in dynamic_mcp._servers.values())
+    if not has_process_servers:
         logger.info("Server cache empty, refreshing...")
-        # Cache server info for ALL enabled process servers (including COLD)
-        for name in process_manager.get_enabled_servers():
+        # Cache server info for ALL servers (including COLD and disabled)
+        index_count = 0
+        for name in process_manager.get_server_names():
             status = process_manager.get_server_status(name)
             dynamic_mcp._servers[name] = ServerInfo(
                 name=name,
@@ -1368,8 +1371,23 @@ async def handle_airis_find(rpc_request: Dict[str, Any], session_id: Optional[st
                 tools_count=status.get("tools_count", 0),
                 source="process"
             )
+            # Also cache tools_index entries for COLD/disabled servers
+            config = process_manager._server_configs.get(name)
+            if config and config.tools_index:
+                for tool_entry in config.tools_index:
+                    tool_name = tool_entry.get("name", "")
+                    if tool_name and tool_name not in dynamic_mcp._tools:
+                        dynamic_mcp._tools[tool_name] = ToolInfo(
+                            name=tool_name,
+                            server=name,
+                            description=tool_entry.get("description", ""),
+                            input_schema={},
+                            source="index"
+                        )
+                        dynamic_mcp._tool_to_server[tool_name] = name
+                        index_count += 1
 
-        logger.info(f"Cached {len(dynamic_mcp._servers)} servers")
+        logger.info(f"Cached {len(dynamic_mcp._servers)} servers, {index_count} tools from index")
 
     # Auto-refresh ProcessManager tools if not yet cached
     # (Docker Gateway tools may be pre-cached at startup, but we still need ProcessManager tools)
@@ -1519,6 +1537,14 @@ async def handle_airis_exec(rpc_request: Dict[str, Any], session_id: Optional[st
 
     logger.info(f"airis-exec: {tool_ref} -> server={server_name}, tool={tool_name}")
 
+    process_manager = get_process_manager()
+
+    # Auto-discovery: if tool not in cache, try tools_index to find the server
+    if not server_name:
+        server_name = dynamic_mcp.get_server_for_tool_from_index(tool_name, process_manager)
+        if server_name:
+            logger.info(f"Auto-discovered tool '{tool_name}' on server '{server_name}' via tools_index")
+
     if not server_name:
         return Response(
             content=json.dumps({
@@ -1532,9 +1558,6 @@ async def handle_airis_exec(rpc_request: Dict[str, Any], session_id: Optional[st
             status_code=200,
             media_type="application/json"
         )
-
-    # Route to ProcessManager (with auto-enable for COLD mode servers)
-    process_manager = get_process_manager()
     if process_manager.is_process_server(server_name):
         config = process_manager._server_configs.get(server_name)
 
@@ -1694,6 +1717,15 @@ async def handle_airis_schema(rpc_request: Dict[str, Any], session_id: Optional[
                 "description": description or "",
                 "inputSchema": full_schema
             }
+
+    # Auto-discovery: if schema not found, try loading from tools_index server
+    if not schema:
+        process_manager = get_process_manager()
+        server_name = dynamic_mcp.get_server_for_tool_from_index(tool_name, process_manager)
+        if server_name:
+            logger.info(f"Auto-loading schema for '{tool_name}' from server '{server_name}'")
+            tools = await dynamic_mcp.load_tools_for_server(server_name, process_manager, force_enable=True)
+            schema = dynamic_mcp.get_tool_schema(tool_name)
 
     if not schema:
         error_data = {

--- a/apps/api/src/app/core/dynamic_mcp.py
+++ b/apps/api/src/app/core/dynamic_mcp.py
@@ -26,7 +26,7 @@ class ToolInfo:
     server: str
     description: str
     input_schema: dict = field(default_factory=dict)
-    source: str = "process"  # "process" or "docker"
+    source: str = "process"  # "process", "docker", or "index"
 
 
 @dataclass
@@ -225,12 +225,31 @@ class DynamicMCP:
                         source="docker"
                     )
 
+        # Cache tools_index from ALL servers (including COLD/disabled)
+        # This enables discovery without starting servers
+        index_count = 0
+        for name in process_manager.get_server_names():
+            config = process_manager._server_configs.get(name)
+            if config and config.tools_index:
+                for tool_entry in config.tools_index:
+                    tool_name = tool_entry.get("name", "")
+                    if tool_name and tool_name not in new_tools:
+                        new_tools[tool_name] = ToolInfo(
+                            name=tool_name,
+                            server=name,
+                            description=tool_entry.get("description", ""),
+                            input_schema={},
+                            source="index"
+                        )
+                        new_tool_to_server[tool_name] = name
+                        index_count += 1
+
         # Atomic swap - replace all caches at once
         self._tools = new_tools
         self._servers = new_servers
         self._tool_to_server = new_tool_to_server
 
-        logger.info(f"Cached {len(self._tools)} HOT tools from {len(self._servers)} servers (COLD tools on-demand)")
+        logger.info(f"Cached {len(self._tools)} tools ({index_count} from index) from {len(self._servers)} servers (COLD tools on-demand)")
 
     async def load_tools_for_server(
         self,
@@ -269,10 +288,11 @@ class DynamicMCP:
         try:
             tools = await process_manager._list_tools_for_server(server_name)
 
-            # Cache the loaded tools
+            # Cache the loaded tools (overwrite index entries with live data)
             for tool in tools:
                 tool_name = tool.get("name", "")
-                if tool_name and tool_name not in self._tools:
+                existing = self._tools.get(tool_name)
+                if tool_name and (not existing or existing.source == "index"):
                     self._tools[tool_name] = ToolInfo(
                         name=tool_name,
                         server=server_name,
@@ -338,13 +358,26 @@ class DynamicMCP:
 
         query_lower = query.lower() if query else None
 
+        # Build query variants for flexible matching
+        query_variants = []
+        if query_lower:
+            query_variants.append(query_lower)
+            # "sequential thinking" -> "sequential-thinking", "sequential_thinking"
+            query_variants.append(query_lower.replace(" ", "-"))
+            query_variants.append(query_lower.replace(" ", "_"))
+            # "sequential-thinking" -> "sequentialthinking"
+            query_variants.append(query_lower.replace("-", "").replace("_", "").replace(" ", ""))
+            # Deduplicate while preserving order
+            query_variants = list(dict.fromkeys(query_variants))
+
         # Search servers
         for name, info in self._servers.items():
             if server and name != server:
                 continue
 
-            if query_lower and query_lower not in name.lower():
-                continue
+            if query_variants:
+                if not any(v in name.lower() for v in query_variants):
+                    continue
 
             matched_servers.append({
                 "name": info.name,
@@ -358,12 +391,13 @@ class DynamicMCP:
             if server and info.server != server:
                 continue
 
-            if query_lower:
-                # Match against name, description, or server
-                if not (
-                    query_lower in name.lower() or
-                    query_lower in info.description.lower() or
-                    query_lower in info.server.lower()
+            if query_variants:
+                name_lower = name.lower()
+                desc_lower = info.description.lower()
+                server_lower = info.server.lower()
+                if not any(
+                    v in name_lower or v in desc_lower or v in server_lower
+                    for v in query_variants
                 ):
                     continue
 
@@ -376,6 +410,28 @@ class DynamicMCP:
             if len(matched_tools) >= limit:
                 break
 
+        # Fallback: search TOOL_CATALOG for tools not yet in cache
+        if not matched_tools and query_lower:
+            from .tool_suggester import TOOL_CATALOG, _extract_keywords
+            query_keywords = set(_extract_keywords(query))
+            if query_keywords:
+                for server_name, tools in TOOL_CATALOG.items():
+                    if server and server_name != server:
+                        continue
+                    for tool_name, keywords in tools.items():
+                        # Skip tools already in cache
+                        if tool_name in self._tools:
+                            continue
+                        if query_keywords & set(keywords):
+                            matched_tools.append({
+                                "name": tool_name,
+                                "server": server_name,
+                                "description": f"[catalog] Keywords: {', '.join(keywords[:5])}",
+                            })
+
+                if matched_tools:
+                    matched_tools = matched_tools[:limit]
+
         return {
             "servers": matched_servers[:limit],
             "tools": matched_tools,
@@ -384,9 +440,17 @@ class DynamicMCP:
         }
 
     def get_tool_schema(self, tool_name: str) -> Optional[dict]:
-        """Get full schema for a specific tool."""
+        """Get full schema for a specific tool.
+
+        Returns None for index-sourced tools (no real schema available)
+        to trigger auto-discovery and server startup.
+        """
         info = self._tools.get(tool_name)
         if not info:
+            return None
+
+        # Index-sourced tools have no real schema - return None to trigger auto-discovery
+        if info.source == "index":
             return None
 
         return {
@@ -399,6 +463,19 @@ class DynamicMCP:
     def get_server_for_tool(self, tool_name: str) -> Optional[str]:
         """Get server name for a tool."""
         return self._tool_to_server.get(tool_name)
+
+    def get_server_for_tool_from_index(self, tool_name: str, process_manager) -> Optional[str]:
+        """
+        Look up server name from tools_index in mcp-config.json.
+        Used for auto-discovery when tool is not in cache.
+        """
+        for name in process_manager.get_server_names():
+            config = process_manager._server_configs.get(name)
+            if config and config.tools_index:
+                for tool_entry in config.tools_index:
+                    if tool_entry.get("name") == tool_name:
+                        return name
+        return None
 
     def parse_tool_reference(self, tool_ref: str) -> tuple[Optional[str], str]:
         """

--- a/apps/api/src/app/core/mcp_config_loader.py
+++ b/apps/api/src/app/core/mcp_config_loader.py
@@ -59,6 +59,12 @@ class McpServerConfig:
     min_ttl: Optional[int] = None
     max_ttl: Optional[int] = None
     adaptive_ttl_enabled: Optional[bool] = None
+    # Tool index for COLD/disabled servers (enables discovery without starting server)
+    tools_index: list[dict] = None
+
+    def __post_init__(self):
+        if self.tools_index is None:
+            self.tools_index = []
 
     def to_process_config(self, idle_timeout: int = 120) -> ProcessConfig:
         """Convert to ProcessConfig for ProcessRunner."""
@@ -187,6 +193,9 @@ def load_mcp_config(config_path: Optional[str] = None) -> dict[str, McpServerCon
         max_ttl = server_def.get("max_ttl")
         adaptive_ttl_enabled = server_def.get("adaptive_ttl_enabled")
 
+        # Parse tools_index for COLD/disabled server discovery
+        tools_index = server_def.get("tools_index", [])
+
         servers[name] = McpServerConfig(
             name=name,
             server_type=server_type,
@@ -200,6 +209,7 @@ def load_mcp_config(config_path: Optional[str] = None) -> dict[str, McpServerCon
             min_ttl=min_ttl,
             max_ttl=max_ttl,
             adaptive_ttl_enabled=adaptive_ttl_enabled,
+            tools_index=tools_index,
         )
 
         logger.debug(f"{name}: type={server_type.value}, mode={mode.value}, enabled={enabled}")

--- a/apps/api/tests/unit/test_dynamic_mcp.py
+++ b/apps/api/tests/unit/test_dynamic_mcp.py
@@ -139,6 +139,69 @@ class TestDynamicMCPFind:
         assert len(results["tools"]) == 0
 
 
+class TestDynamicMCPFindQueryVariants:
+    """Tests for query normalization in find()"""
+
+    def test_find_with_space_matches_hyphen(self, populated_dynamic_mcp):
+        """'sequential thinking' should match 'sequential-thinking' server."""
+        populated_dynamic_mcp._servers["sequential-thinking"] = ServerInfo(
+            name="sequential-thinking", enabled=False, mode="cold",
+            tools_count=1, source="process"
+        )
+        results = populated_dynamic_mcp.find(query="sequential thinking")
+        server_names = [s["name"] for s in results["servers"]]
+        assert "sequential-thinking" in server_names
+
+    def test_find_with_hyphen_matches_no_separator(self, populated_dynamic_mcp):
+        """'sequential-thinking' query should also try 'sequentialthinking'."""
+        populated_dynamic_mcp._tools["sequentialthinking"] = ToolInfo(
+            name="sequentialthinking", server="seq-server",
+            description="Thinking tool", input_schema={}, source="index"
+        )
+        populated_dynamic_mcp._tool_to_server["sequentialthinking"] = "seq-server"
+        results = populated_dynamic_mcp.find(query="sequential-thinking")
+        tool_names = [t["name"] for t in results["tools"]]
+        assert "sequentialthinking" in tool_names
+
+    def test_find_catalog_fallback(self, dynamic_mcp):
+        """When no cache matches, TOOL_CATALOG should be used as fallback."""
+        results = dynamic_mcp.find(query="stripe invoice")
+        # Should find tools from TOOL_CATALOG
+        tool_names = [t["name"] for t in results["tools"]]
+        assert "create_invoice" in tool_names
+
+    def test_find_catalog_fallback_not_used_when_cache_matches(self, populated_dynamic_mcp):
+        """TOOL_CATALOG fallback should not trigger when cache has matches."""
+        results = populated_dynamic_mcp.find(query="entities")
+        # Should find from cache, not catalog
+        assert len(results["tools"]) == 2
+        for t in results["tools"]:
+            assert "[catalog]" not in t.get("description", "")
+
+
+class TestDynamicMCPAutoDiscovery:
+    """Tests for get_server_for_tool_from_index."""
+
+    def test_auto_discovery_finds_tool(self, dynamic_mcp):
+        """Should find server for tool via tools_index."""
+        from unittest.mock import MagicMock
+
+        mock_pm = MagicMock()
+        mock_pm.get_server_names.return_value = ["tavily", "stripe"]
+        mock_pm._server_configs = {
+            "tavily": MagicMock(tools_index=[
+                {"name": "tavily-search", "description": "Search"},
+            ]),
+            "stripe": MagicMock(tools_index=[
+                {"name": "create_customer", "description": "Create customer"},
+            ]),
+        }
+
+        assert dynamic_mcp.get_server_for_tool_from_index("tavily-search", mock_pm) == "tavily"
+        assert dynamic_mcp.get_server_for_tool_from_index("create_customer", mock_pm) == "stripe"
+        assert dynamic_mcp.get_server_for_tool_from_index("nonexistent", mock_pm) is None
+
+
 class TestDynamicMCPSchema:
     """Tests for airis-schema functionality"""
 
@@ -155,6 +218,15 @@ class TestDynamicMCPSchema:
         """Test getting schema for non-existent tool"""
         schema = populated_dynamic_mcp.get_tool_schema("nonexistent")
 
+        assert schema is None
+
+    def test_get_tool_schema_returns_none_for_index_source(self, populated_dynamic_mcp):
+        """Index-sourced tools should return None to trigger auto-discovery."""
+        populated_dynamic_mcp._tools["indexed_tool"] = ToolInfo(
+            name="indexed_tool", server="some-server",
+            description="From index", input_schema={}, source="index"
+        )
+        schema = populated_dynamic_mcp.get_tool_schema("indexed_tool")
         assert schema is None
 
 
@@ -497,7 +569,7 @@ class TestRefreshCacheHotOnly:
 
     @pytest.mark.asyncio
     async def test_refresh_cache_hot_only_skips_cold(self):
-        """refresh_cache_hot_only should only load HOT server tools."""
+        """refresh_cache_hot_only should only load HOT server tools (plus index)."""
         from unittest.mock import AsyncMock, MagicMock
 
         mcp = DynamicMCP()
@@ -506,6 +578,7 @@ class TestRefreshCacheHotOnly:
         mock_pm = MagicMock()
         mock_pm.get_enabled_servers.return_value = ["hot-server", "cold-server"]
         mock_pm.get_hot_servers.return_value = ["hot-server"]
+        mock_pm.get_server_names.return_value = ["hot-server", "cold-server"]
         mock_pm.get_server_status.side_effect = lambda name: {
             "enabled": True,
             "mode": "hot" if name == "hot-server" else "cold",
@@ -523,8 +596,8 @@ class TestRefreshCacheHotOnly:
 
         mock_pm._list_tools_for_server = list_tools
         mock_pm._server_configs = {
-            "hot-server": MagicMock(enabled=True),
-            "cold-server": MagicMock(enabled=True),
+            "hot-server": MagicMock(enabled=True, tools_index=[]),
+            "cold-server": MagicMock(enabled=True, tools_index=[]),
         }
 
         await mcp.refresh_cache_hot_only(mock_pm, docker_tools=None)
@@ -541,6 +614,82 @@ class TestRefreshCacheHotOnly:
         # Verify mode is correctly set
         assert mcp._servers["hot-server"].mode == "hot"
         assert mcp._servers["cold-server"].mode == "cold"
+
+    @pytest.mark.asyncio
+    async def test_refresh_cache_hot_only_loads_tools_index(self):
+        """refresh_cache_hot_only should cache tools from tools_index."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        mcp = DynamicMCP()
+
+        mock_pm = MagicMock()
+        mock_pm.get_enabled_servers.return_value = ["hot-server"]
+        mock_pm.get_hot_servers.return_value = ["hot-server"]
+        mock_pm.get_server_names.return_value = ["hot-server", "cold-server"]
+        mock_pm.get_server_status.side_effect = lambda name: {
+            "enabled": name == "hot-server",
+            "mode": "hot" if name == "hot-server" else "cold",
+            "tools_count": 0
+        }
+
+        async def list_tools(name):
+            if name == "hot-server":
+                return [{"name": "hot_tool", "description": "HOT", "inputSchema": {}}]
+            return []
+
+        mock_pm._list_tools_for_server = list_tools
+        mock_pm._server_configs = {
+            "hot-server": MagicMock(enabled=True, tools_index=[]),
+            "cold-server": MagicMock(
+                enabled=False,
+                tools_index=[
+                    {"name": "cold_tool_1", "description": "Cold tool from index"},
+                    {"name": "cold_tool_2", "description": "Another cold tool"},
+                ]
+            ),
+        }
+
+        await mcp.refresh_cache_hot_only(mock_pm, docker_tools=None)
+
+        # HOT tool should be cached
+        assert "hot_tool" in mcp._tools
+        assert mcp._tools["hot_tool"].source == "process"
+
+        # tools_index tools should also be cached
+        assert "cold_tool_1" in mcp._tools
+        assert mcp._tools["cold_tool_1"].source == "index"
+        assert mcp._tools["cold_tool_1"].server == "cold-server"
+        assert "cold_tool_2" in mcp._tools
+
+    @pytest.mark.asyncio
+    async def test_tools_index_does_not_override_live_tools(self):
+        """Live tools should take priority over tools_index entries."""
+        from unittest.mock import MagicMock
+
+        mcp = DynamicMCP()
+
+        mock_pm = MagicMock()
+        mock_pm.get_enabled_servers.return_value = ["server-a"]
+        mock_pm.get_hot_servers.return_value = ["server-a"]
+        mock_pm.get_server_names.return_value = ["server-a"]
+        mock_pm.get_server_status.return_value = {"enabled": True, "mode": "hot", "tools_count": 1}
+
+        async def list_tools(name):
+            return [{"name": "shared_tool", "description": "Live version", "inputSchema": {"live": True}}]
+
+        mock_pm._list_tools_for_server = list_tools
+        mock_pm._server_configs = {
+            "server-a": MagicMock(
+                enabled=True,
+                tools_index=[{"name": "shared_tool", "description": "Index version"}]
+            ),
+        }
+
+        await mcp.refresh_cache_hot_only(mock_pm, docker_tools=None)
+
+        # Live tool should win
+        assert mcp._tools["shared_tool"].description == "Live version"
+        assert mcp._tools["shared_tool"].source == "process"
 
 
 class TestApplySchemaPartitioningDynamicMode:

--- a/mcp-config.json.example
+++ b/mcp-config.json.example
@@ -8,7 +8,11 @@
       ],
       "env": {},
       "enabled": true,
-      "mode": "cold"
+      "mode": "cold",
+      "tools_index": [
+        {"name": "resolve-library-id", "description": "Resolve a library name to its Context7 ID for documentation lookup"},
+        {"name": "get-library-docs", "description": "Get official documentation for a library by its Context7 ID"}
+      ]
     },
     "fetch": {
       "command": "uvx",
@@ -17,7 +21,10 @@
       ],
       "env": {},
       "enabled": true,
-      "mode": "cold"
+      "mode": "cold",
+      "tools_index": [
+        {"name": "fetch", "description": "Fetch content from a URL and return it as markdown"}
+      ]
     },
     "filesystem": {
       "command": "npx",
@@ -28,7 +35,14 @@
       ],
       "env": {},
       "enabled": false,
-      "mode": "cold"
+      "mode": "cold",
+      "tools_index": [
+        {"name": "read_file", "description": "Read complete contents of a file"},
+        {"name": "write_file", "description": "Write content to a file (create or overwrite)"},
+        {"name": "list_directory", "description": "List directory contents with file types"},
+        {"name": "search_files", "description": "Search for files matching a pattern"},
+        {"name": "move_file", "description": "Move or rename a file or directory"}
+      ]
     },
     "git": {
       "command": "npx",
@@ -38,7 +52,13 @@
       ],
       "env": {},
       "enabled": false,
-      "mode": "cold"
+      "mode": "cold",
+      "tools_index": [
+        {"name": "git_status", "description": "Show working tree status"},
+        {"name": "git_diff", "description": "Show changes between commits or working tree"},
+        {"name": "git_commit", "description": "Create a new commit"},
+        {"name": "git_log", "description": "Show commit history"}
+      ]
     },
     "memory": {
       "command": "npx",
@@ -50,7 +70,16 @@
         "MEMORY_FILE_PATH": "/app/data/memory.json"
       },
       "enabled": true,
-      "mode": "cold"
+      "mode": "cold",
+      "tools_index": [
+        {"name": "create_entities", "description": "Create multiple new entities in the knowledge graph"},
+        {"name": "search_nodes", "description": "Search for nodes in the knowledge graph"},
+        {"name": "add_observations", "description": "Add observations to existing entities"},
+        {"name": "delete_entities", "description": "Delete entities from the knowledge graph"},
+        {"name": "open_nodes", "description": "Open specific nodes by name"},
+        {"name": "create_relations", "description": "Create relations between entities"},
+        {"name": "read_graph", "description": "Read the entire knowledge graph"}
+      ]
     },
     "mindbase": {
       "command": "npx",
@@ -97,7 +126,10 @@
       ],
       "env": {},
       "enabled": true,
-      "mode": "cold"
+      "mode": "cold",
+      "tools_index": [
+        {"name": "sequentialthinking", "description": "Dynamic problem-solving through sequential thinking steps with branching and revision"}
+      ]
     },
     "serena": {
       "profile": "${SERENA_MODE:-serena-remote}",
@@ -114,7 +146,14 @@
       ],
       "env": {},
       "enabled": true,
-      "mode": "cold"
+      "mode": "cold",
+      "tools_index": [
+        {"name": "tavily-search", "description": "Search the web for current information on any topic"},
+        {"name": "tavily-extract", "description": "Extract content from URLs in markdown format"},
+        {"name": "tavily-crawl", "description": "Crawl a website starting from a URL with configurable depth"},
+        {"name": "tavily-map", "description": "Map a website URL structure"},
+        {"name": "tavily-research", "description": "Comprehensive multi-step research on a topic"}
+      ]
     },
     "time": {
       "command": "npx",
@@ -124,7 +163,11 @@
       ],
       "env": {},
       "enabled": false,
-      "mode": "cold"
+      "mode": "cold",
+      "tools_index": [
+        {"name": "get_current_time", "description": "Get current time in a specific timezone"},
+        {"name": "convert_time", "description": "Convert time between timezones"}
+      ]
     },
     "supabase": {
       "command": "npx",
@@ -136,7 +179,12 @@
       ],
       "env": {},
       "enabled": true,
-      "mode": "cold"
+      "mode": "cold",
+      "tools_index": [
+        {"name": "query", "description": "Execute SQL query against a Supabase database"},
+        {"name": "list_tables", "description": "List all tables in the Supabase database"},
+        {"name": "describe_table", "description": "Get schema details for a specific table"}
+      ]
     },
     "playwright": {
       "command": "npx",
@@ -146,7 +194,14 @@
       ],
       "env": {},
       "enabled": true,
-      "mode": "cold"
+      "mode": "cold",
+      "tools_index": [
+        {"name": "browser_navigate", "description": "Navigate to a URL in the browser"},
+        {"name": "browser_screenshot", "description": "Take a screenshot of the current page"},
+        {"name": "browser_click", "description": "Click an element on the page"},
+        {"name": "browser_type", "description": "Type text into an input field"},
+        {"name": "browser_wait_for_page_load", "description": "Wait for the page to finish loading"}
+      ]
     },
     "magic": {
       "command": "npx",
@@ -159,7 +214,10 @@
       },
       "enabled": true,
       "mode": "cold",
-      "_comment": "Get API key at https://21st.dev"
+      "_comment": "Get API key at https://21st.dev",
+      "tools_index": [
+        {"name": "21st_magic_component", "description": "Generate a UI component using 21st.dev Magic"}
+      ]
     },
     "morphllm": {
       "command": "npx",
@@ -173,7 +231,11 @@
       },
       "enabled": true,
       "mode": "cold",
-      "_comment": "Get API key at https://morphllm.com"
+      "_comment": "Get API key at https://morphllm.com",
+      "tools_index": [
+        {"name": "edit_file", "description": "Edit a file using AI-powered fast apply"},
+        {"name": "warpgrep_codebase_search", "description": "Search codebase using semantic code search"}
+      ]
     },
     "chrome-devtools": {
       "command": "npx",
@@ -183,7 +245,12 @@
       ],
       "env": {},
       "enabled": true,
-      "mode": "cold"
+      "mode": "cold",
+      "tools_index": [
+        {"name": "devtools_evaluate", "description": "Execute JavaScript in the browser DevTools console"},
+        {"name": "devtools_screenshot", "description": "Take a screenshot via Chrome DevTools Protocol"},
+        {"name": "devtools_network", "description": "Monitor network requests via DevTools"}
+      ]
     },
     "stripe": {
       "command": "npx",
@@ -197,7 +264,14 @@
       "env": {},
       "enabled": false,
       "mode": "cold",
-      "_comment": "Set STRIPE_SECRET_KEY in .env"
+      "_comment": "Set STRIPE_SECRET_KEY in .env",
+      "tools_index": [
+        {"name": "create_customer", "description": "Create a new Stripe customer"},
+        {"name": "create_invoice", "description": "Create a new invoice for a customer"},
+        {"name": "create_payment_intent", "description": "Create a payment intent for processing payments"},
+        {"name": "list_customers", "description": "List Stripe customers"},
+        {"name": "list_invoices", "description": "List invoices with optional filters"}
+      ]
     },
     "twilio": {
       "command": "npx",
@@ -226,7 +300,13 @@
         "CLOUDFLARE_ACCOUNT_ID": "${CLOUDFLARE_ACCOUNT_ID}"
       },
       "enabled": false,
-      "mode": "cold"
+      "mode": "cold",
+      "tools_index": [
+        {"name": "cloudflare_kv_get", "description": "Get a value from Cloudflare KV"},
+        {"name": "cloudflare_kv_put", "description": "Put a value in Cloudflare KV"},
+        {"name": "cloudflare_workers_list", "description": "List Cloudflare Workers"},
+        {"name": "cloudflare_dns_records_list", "description": "List DNS records for a zone"}
+      ]
     },
     "github": {
       "command": "npx",
@@ -238,7 +318,14 @@
         "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
       },
       "enabled": true,
-      "mode": "cold"
+      "mode": "cold",
+      "tools_index": [
+        {"name": "create_issue", "description": "Create a new GitHub issue"},
+        {"name": "list_issues", "description": "List issues in a repository"},
+        {"name": "create_pull_request", "description": "Create a new pull request"},
+        {"name": "search_repositories", "description": "Search for GitHub repositories"},
+        {"name": "get_file_contents", "description": "Get contents of a file in a repository"}
+      ]
     },
     "postgres": {
       "command": "npx",
@@ -249,7 +336,10 @@
       ],
       "env": {},
       "enabled": false,
-      "mode": "cold"
+      "mode": "cold",
+      "tools_index": [
+        {"name": "query", "description": "Execute a SQL query against the PostgreSQL database"}
+      ]
     }
   },
   "profiles": {


### PR DESCRIPTION
## Summary

- COLD/disabledサーバーのツールが`airis-find`で発見不可能だった問題を解決
- `mcp-config.json`に`tools_index`フィールドを追加し、サーバー起動なしでツール名・説明を事前宣言可能に
- `airis-exec`/`airis-schema`にauto-discovery機能を追加（tools_indexからサーバー特定→自動起動）
- 検索品質改善: クエリ正規化（スペース↔ハイフン↔アンダースコア変換）+ TOOL_CATALOGフォールバック

## Before / After

| Query | Before | After |
|---|---|---|
| `sequential thinking` | 0件 | 1件 (クエリ正規化) |
| `sequentialthinking` | 0件 | 1件 (tools_index) |
| `tavily` | サーバー名のみ | 5ツール表示 |
| `stripe` | 0件 | 5ツール表示 |
| `airis-schema sequentialthinking` | not found | フルスキーマ (auto-discovery) |

## Test plan

- [x] 全42ユニットテスト通過 (`test_dynamic_mcp.py`)
- [x] 全388ユニットテスト通過
- [x] Docker rebuild + 操作感テスト完了
- [ ] CI通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)