### PR TITLE
chore: rename dev/next branch to stg, update GA workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,11 @@ on:
   push:
     branches:
       - main
-      - next
+      - stg
   pull_request:
     branches:
       - main
+      - stg
 
 jobs:
   # Detect which paths changed
@@ -108,7 +109,7 @@ jobs:
     needs: [test-python, build-typescript]
     if: |
       always() &&
-      github.ref == 'refs/heads/next' &&
+      github.ref == 'refs/heads/stg' &&
       github.event_name == 'push' &&
       !contains(needs.*.result, 'failure')
     runs-on: ubuntu-latest
@@ -126,11 +127,11 @@ jobs:
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
 
-      - name: Merge next to main
+      - name: Merge stg to main
         run: |
           git fetch origin main
           git checkout main
-          git merge origin/next --no-edit
+          git merge origin/stg --no-edit
           git push origin main
 
-          echo "✅ Merged next → main"
+          echo "✅ Merged stg → main"

--- a/.github/workflows/sync-stg.yml
+++ b/.github/workflows/sync-stg.yml
@@ -1,4 +1,4 @@
-name: Sync main to next
+name: Sync main to stg
 
 on:
   push:
@@ -26,29 +26,29 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Prepare sync branch from next
+      - name: Prepare sync branch from stg
         run: |
-          git fetch origin next
-          git checkout -B sync/main-to-next origin/next
-          git merge --no-ff origin/main -m "chore: sync next with main" || { \
+          git fetch origin stg
+          git checkout -B sync/main-to-stg origin/stg
+          git merge --no-ff origin/main -m "chore: sync stg with main" || { \
             echo "::error::Merge conflicts detected. Resolve manually."; \
             exit 1; \
           }
-          git push -f origin sync/main-to-next
+          git push -f origin sync/main-to-stg
 
-      - name: Create pull request into next
+      - name: Create pull request into stg
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "chore: sync next with main"
+          commit-message: "chore: sync stg with main"
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
-          title: "chore: sync next with main"
+          title: "chore: sync stg with main"
           body: |
-            Automated PR to keep `next` up to date with `main`.
+            Automated PR to keep `stg` up to date with `main`.
 
             This was triggered by a push to `main`.
-          base: next
-          branch: sync/main-to-next
+          base: stg
+          branch: sync/main-to-stg
           delete-branch: true
           skip-if-no-changes: true


### PR DESCRIPTION
## Summary
- GA ワークフローの `next` 参照を全て `stg` に変更
- `sync-next.yml` → `sync-stg.yml` にリネーム
- CI の PR トリガーに `stg` ブランチ追加

## Changed files
- `.github/workflows/ci.yml`: next → stg (push/PR triggers + merge job)
- `.github/workflows/sync-next.yml` → `sync-stg.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)