### PR TITLE
stg -> main: docker cache, event-driven runner, rate limit cleanup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,58 @@
+# Version control / CI metadata
+.git/
+.github/
+.gitignore
+.gitattributes
+
+# Python tooling / build artefacts
+**/__pycache__/
+**/*.pyc
+**/*.pyo
+**/*.pyd
+**/.pytest_cache/
+**/.mypy_cache/
+**/.ruff_cache/
+**/.coverage
+**/htmlcov/
+**/.tox/
+**/.venv/
+**/venv/
+**/*.egg-info/
+**/build/
+**/dist/
+
+# Node tooling / build artefacts
+**/node_modules/
+**/.next/
+**/.turbo/
+**/.pnpm-store/
+**/pnpm-lock.yaml.bak
+
+# Local developer caches
+.cache/
+.devbox/
+.vscode/
+.idea/
+.claude/
+.worktrees/
+.DS_Store
+
+# Secrets and environment files — never ship these in the image context
+.env
+.env.*
+!.env.example
+secrets/
+
+# Large local artefacts that are not needed in the build context
+docs/
+plans/
+testdata/
+tmp/
+*.log
+*.bak
+*.swp
+
+# Project-level cruft
+coverage/
+playwright-report/
+test-results/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Ensure PR from stg to main exists
+      - name: Report stg status for promotion to main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -164,14 +164,26 @@ jobs:
             --jq '.[0].number // empty')
 
           if [ -n "${existing_pr}" ]; then
-            echo "Existing PR #${existing_pr} already open for stg -> main."
+            echo "Existing PR #${existing_pr} is open for stg -> main. Commenting with the new commit."
             gh pr comment "${existing_pr}" --body \
               "New commit landed on \`stg\` (${GITHUB_SHA}). CI passed — ready for review."
             exit 0
           fi
 
-          gh pr create \
-            --base main \
-            --head stg \
-            --title "stg -> main: automated promotion" \
-            --body "Automated promotion PR opened by CI after stg tests passed. Merge via the GitHub UI or the merge queue so the main branch ruleset is satisfied."
+          # No PR exists and GitHub Actions is not permitted to open one (the
+          # repo policy "Allow GitHub Actions to create and approve pull
+          # requests" is disabled). Report a green status with instructions so
+          # the CI stays actionable without a failing job.
+          cat <<EOT
+          No open PR from stg to main. stg has commits that need to be promoted.
+          Create the promotion PR manually with:
+
+              gh pr create --base main --head stg \\
+                --title "stg -> main: promotion" \\
+                --body "Promoting stg to main."
+
+          (GitHub Actions cannot open the PR automatically because the repo
+          setting "Allow GitHub Actions to create and approve pull requests"
+          is disabled. Enable it under Settings -> Actions -> General if you
+          want this job to create the PR itself.)
+          EOT

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,10 +1,15 @@
+# syntax=docker/dockerfile:1.7
 # FastAPI Hybrid MCP Gateway
 # Supports both Docker MCP Gateway proxy and direct uvx/npx process management
 # Includes browser automation support for Playwright and chrome-devtools MCP servers
 FROM python:3.12-slim
 
-# Install system dependencies including Chromium for browser automation
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Keep apt lists across layers in a BuildKit cache so repeated builds don't
+# re-download the same packages. rm -rf is NOT needed because the cache mount
+# is not written into the image layer.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends \
     curl \
     git \
     # Chromium browser for Playwright/chrome-devtools MCP servers
@@ -41,16 +46,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libcairo2 \
     libasound2 \
     fonts-liberation \
-    fonts-noto-color-emoji \
-    && rm -rf /var/lib/apt/lists/*
+    fonts-noto-color-emoji
 
 # Install Node.js (for npx MCP servers)
-RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
-    && apt-get install -y nodejs \
-    && rm -rf /var/lib/apt/lists/*
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y nodejs
 
 # Install uv (for uvx MCP servers)
-RUN pip install --no-cache-dir uv
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install uv
 
 # Configure browser paths for MCP servers
 ENV PLAYWRIGHT_BROWSERS_PATH=/app/.cache/ms-playwright
@@ -71,32 +77,50 @@ RUN mkdir -p /app/.cache/ms-playwright
 RUN node --version && npm --version && npx --version && uvx --help || true
 RUN chromium --version || echo "Chromium installed at /usr/bin/chromium"
 
-# Pre-install Playwright Chromium (uses system chromium, installs dependencies)
-RUN npx playwright install chromium --with-deps || echo "Playwright will use system Chromium"
+# Pre-install Playwright Chromium (uses system chromium, installs dependencies).
+# Use /tmp/playwright-cache as a temporary BuildKit cache; the final browsers
+# live under PLAYWRIGHT_BROWSERS_PATH (/app/.cache/ms-playwright) and are not
+# cached because they must stay in the final image.
+RUN --mount=type=cache,target=/root/.npm,sharing=locked \
+    npx playwright install chromium --with-deps || echo "Playwright will use system Chromium"
 
 WORKDIR /app
 
-# Copy MCP server sources and build them (bundled with esbuild, no node_modules needed at runtime)
+# Copy MCP server sources and build them (bundled with esbuild, no node_modules needed at runtime).
+# package.json / tsconfig.json are copied BEFORE src/ so that source-only changes
+# reuse the cached npm install layer.
+#
 # Build gateway-control
 COPY apps/gateway-control/package*.json /tmp/gateway-control/
-COPY apps/gateway-control/src /tmp/gateway-control/src/
 COPY apps/gateway-control/tsconfig.json /tmp/gateway-control/
-RUN cd /tmp/gateway-control && npm install && npm run build \
-    && mkdir -p /app/gateway-control && cp dist/index.js /app/gateway-control/ \
+COPY apps/gateway-control/src /tmp/gateway-control/src/
+RUN --mount=type=cache,target=/root/.npm,sharing=locked \
+    cd /tmp/gateway-control \
+    && npm install \
+    && npm run build \
+    && mkdir -p /app/gateway-control \
+    && cp dist/index.js /app/gateway-control/ \
     && rm -rf /tmp/gateway-control
 
 # Build airis-commands
 COPY apps/airis-commands/package*.json /tmp/airis-commands/
-COPY apps/airis-commands/src /tmp/airis-commands/src/
 COPY apps/airis-commands/tsconfig.json /tmp/airis-commands/
-RUN cd /tmp/airis-commands && npm install && npm run build \
-    && mkdir -p /app/airis-commands && cp dist/index.js /app/airis-commands/ \
+COPY apps/airis-commands/src /tmp/airis-commands/src/
+RUN --mount=type=cache,target=/root/.npm,sharing=locked \
+    cd /tmp/airis-commands \
+    && npm install \
+    && npm run build \
+    && mkdir -p /app/airis-commands \
+    && cp dist/index.js /app/airis-commands/ \
     && rm -rf /tmp/airis-commands
 
-# Copy Python API source and install
+# Copy Python API source and install. `-e .` requires the source tree, so we
+# keep the single COPY; the uv cache mount still speeds up repeat builds by
+# reusing the downloaded wheels.
 COPY apps/api /app/api-src
 WORKDIR /app/api-src
-RUN uv pip install --system -e .
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --system -e .
 
 # Copy config files (can be overridden by volume mounts)
 COPY mcp-config.json.example /app/mcp-config.json

--- a/apps/api/src/app/core/process_runner.py
+++ b/apps/api/src/app/core/process_runner.py
@@ -90,6 +90,10 @@ class ProcessRunner:
         self._stderr_task: Optional[asyncio.Task] = None
         self._lock = asyncio.Lock()
 
+        # Condition used to broadcast state transitions. ensure_ready() waits
+        # on this instead of polling self._state every 50ms.
+        self._state_cond = asyncio.Condition()
+
         # Server capabilities (populated after initialize)
         self._server_info: dict[str, Any] = {}
         self._tools: list[dict[str, Any]] = []
@@ -115,6 +119,17 @@ class ProcessRunner:
     @property
     def is_ready(self) -> bool:
         return self._state == ProcessState.READY
+
+    async def _set_state(self, new_state: ProcessState) -> None:
+        """Update state and wake anyone awaiting a transition.
+
+        Use this instead of assigning to `self._state` directly so that
+        `ensure_ready_with_error` can wait on an asyncio.Condition rather
+        than polling every 50 milliseconds.
+        """
+        async with self._state_cond:
+            self._state = new_state
+            self._state_cond.notify_all()
 
     @property
     def tools(self) -> list[dict[str, Any]]:
@@ -221,16 +236,28 @@ class ProcessRunner:
             if self._state == ProcessState.RUNNING:
                 await self._initialize()
 
-        # Wait for READY state
-        start = time.time()
-        while time.time() - start < timeout:
-            if self._state == ProcessState.READY:
-                return (True, None)
-            if self._state == ProcessState.STOPPED:
-                return (False, self._last_error)
-            await asyncio.sleep(0.05)
+        # Wait for READY (or STOPPED) via Condition instead of 50ms polling.
+        deadline = time.monotonic() + timeout
+        async with self._state_cond:
+            while True:
+                if self._state == ProcessState.READY:
+                    return (True, None)
+                if self._state == ProcessState.STOPPED:
+                    return (False, self._last_error)
 
-        return (False, f"Timeout waiting for server to be ready after {timeout}s")
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return (
+                        False,
+                        f"Timeout waiting for server to be ready after {timeout}s",
+                    )
+                try:
+                    await asyncio.wait_for(self._state_cond.wait(), timeout=remaining)
+                except asyncio.TimeoutError:
+                    return (
+                        False,
+                        f"Timeout waiting for server to be ready after {timeout}s",
+                    )
 
     async def ensure_ready(self, timeout: float = 30.0) -> bool:
         """
@@ -244,7 +271,7 @@ class ProcessRunner:
 
     async def _start_process(self):
         """Start the subprocess."""
-        self._state = ProcessState.STARTING
+        await self._set_state(ProcessState.STARTING)
         self._spawn_count += 1
 
         # Build environment
@@ -268,7 +295,7 @@ class ProcessRunner:
                 limit=STDOUT_BUFFER_LIMIT,
             )
 
-            self._state = ProcessState.RUNNING
+            await self._set_state(ProcessState.RUNNING)
             self._last_used = time.time()
             self._started_at = time.time()
 
@@ -281,13 +308,13 @@ class ProcessRunner:
 
         except Exception as e:
             logger.error(f"Failed to start {self.config.name}: {e}")
-            self._state = ProcessState.STOPPED
             self._last_error = str(e)
+            await self._set_state(ProcessState.STOPPED)
             raise
 
     async def _initialize(self):
         """Send initialize request and wait for response."""
-        self._state = ProcessState.INITIALIZING
+        await self._set_state(ProcessState.INITIALIZING)
         cold_start_begin = time.time()
 
         # MCP initialize request
@@ -315,8 +342,8 @@ class ProcessRunner:
             if "error" in response:
                 error_msg = str(response['error'])
                 logger.error(f"{self.config.name} initialize failed: {error_msg}")
-                self._state = ProcessState.STOPPED
                 self._last_error = error_msg
+                await self._set_state(ProcessState.STOPPED)
                 return
 
             self._server_info = response.get("result", {})
@@ -338,13 +365,13 @@ class ProcessRunner:
             self._cold_start_time = time.time() - cold_start_begin
             self._update_ttl()
 
-            self._state = ProcessState.READY
+            await self._set_state(ProcessState.READY)
             logger.info(f"{self.config.name} is READY with {len(self._tools)} tools, {len(self._prompts)} prompts (cold start: {self._cold_start_time:.1f}s, TTL: {self._current_ttl:.0f}s)")
 
         except Exception as e:
             logger.error(f"{self.config.name} initialize error: {e}")
-            self._state = ProcessState.STOPPED
             self._last_error = str(e)
+            await self._set_state(ProcessState.STOPPED)
 
     async def _fetch_tools(self):
         """Fetch available tools from the server."""
@@ -724,7 +751,7 @@ class ProcessRunner:
         if self._state in (ProcessState.STOPPING, ProcessState.STOPPED):
             return
 
-        self._state = ProcessState.STOPPING
+        await self._set_state(ProcessState.STOPPING)
 
         # Cancel pending requests
         for future in self._pending_requests.values():
@@ -756,11 +783,11 @@ class ProcessRunner:
             logger.info(f"{self.config.name} stopped")
 
         self._proc = None
-        self._state = ProcessState.STOPPED
         self._tools = []
         self._prompts = []
         self._server_info = {}
         self._started_at = None
+        await self._set_state(ProcessState.STOPPED)
 
     def get_metrics(self) -> dict[str, Any]:
         """

--- a/apps/api/src/app/main.py
+++ b/apps/api/src/app/main.py
@@ -260,9 +260,30 @@ async def lifespan(app: FastAPI):
         name="periodic_queue_cleanup",
     )
 
+    # Start periodic cleanup of expired rate-limit entries so the in-memory
+    # store does not grow unbounded on long-running instances.
+    async def _periodic_rate_limit_cleanup():
+        from .middleware.rate_limit import get_rate_limit_store
+
+        store = get_rate_limit_store()
+        while True:
+            await asyncio.sleep(300)  # every 5 minutes
+            try:
+                removed = store.cleanup_expired()
+                if removed > 0:
+                    logger.info(f"Cleaned up {removed} expired rate-limit entries")
+            except Exception as e:
+                logger.warning(f"Rate limit cleanup error: {e}")
+
+    rate_limit_cleanup_task = _spawn_background_task(
+        _periodic_rate_limit_cleanup(),
+        name="periodic_rate_limit_cleanup",
+    )
+
     yield
 
     cleanup_task.cancel()
+    rate_limit_cleanup_task.cancel()
 
     # Graceful shutdown with timeout
     logger.info(f"Shutting down (timeout: {SHUTDOWN_TIMEOUT}s)...")

--- a/apps/api/src/app/middleware/rate_limit.py
+++ b/apps/api/src/app/middleware/rate_limit.py
@@ -7,6 +7,7 @@ use Redis-backed rate limiting (see DEPLOYMENT.md).
 
 Key priority: API-Key header > client IP
 """
+import hashlib
 import ipaddress
 import os
 import time
@@ -101,6 +102,43 @@ class RateLimitStore:
         """Clear all entries. Useful for testing."""
         self._store.clear()
 
+    def cleanup_expired(self, window: int = RATE_LIMIT_WINDOW) -> int:
+        """Drop entries whose window has already expired.
+
+        The fixed-window algorithm never needs stale entries: if the window
+        has passed, the very next request for that key would reset it
+        anyway. Returning the stale entries to the garbage collector keeps
+        memory bounded for workloads with a long tail of one-shot clients
+        (short-lived CDN edges, CI runners, pentest scanners, …).
+
+        Args:
+            window: Rate limit window in seconds. Entries older than
+                ``window`` seconds are evicted.
+
+        Returns:
+            Number of entries removed.
+        """
+        now = time.time()
+        expired_keys = [
+            key
+            for key, entry in self._store.items()
+            if now - entry.window_start >= window
+        ]
+        for key in expired_keys:
+            self._store.pop(key, None)
+        return len(expired_keys)
+
+    def __len__(self) -> int:
+        return len(self._store)
+
+
+def _hash_key(key: str) -> str:
+    """Return a short, non-reversible identifier for a rate-limit key.
+
+    Used in log messages so the raw API key / IP never hits the log stream.
+    """
+    return hashlib.sha256(key.encode("utf-8")).hexdigest()[:12]
+
 
 # Global store instance
 _rate_limit_store = RateLimitStore()
@@ -138,7 +176,9 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
 
         if not allowed:
             logger.warning(
-                f"Rate limit exceeded for key={key[:20]}... limit={limit}/min"
+                "Rate limit exceeded for key=%s limit=%d/min",
+                _hash_key(key),
+                limit,
             )
             return JSONResponse(
                 status_code=429,

--- a/apps/api/tests/unit/test_rate_limit_cleanup.py
+++ b/apps/api/tests/unit/test_rate_limit_cleanup.py
@@ -1,0 +1,56 @@
+"""Tests for rate limit store cleanup and log key redaction (issue #102)."""
+from __future__ import annotations
+
+import time
+
+from app.middleware.rate_limit import (
+    RateLimitStore,
+    _hash_key,
+)
+
+
+def test_cleanup_removes_expired_entries():
+    store = RateLimitStore()
+    store.check_and_increment("alice", limit=10, window=60)
+    store.check_and_increment("bob", limit=10, window=60)
+
+    # Age alice's entry past the window.
+    store._store["alice"].window_start = time.time() - 120
+
+    removed = store.cleanup_expired(window=60)
+
+    assert removed == 1
+    assert "alice" not in store._store
+    assert "bob" in store._store
+
+
+def test_cleanup_keeps_fresh_entries():
+    store = RateLimitStore()
+    store.check_and_increment("fresh", limit=10, window=60)
+
+    removed = store.cleanup_expired(window=60)
+
+    assert removed == 0
+    assert "fresh" in store._store
+
+
+def test_cleanup_on_empty_store_is_a_noop():
+    store = RateLimitStore()
+    assert store.cleanup_expired() == 0
+
+
+def test_len_reports_entry_count():
+    store = RateLimitStore()
+    assert len(store) == 0
+    store.check_and_increment("x", limit=1, window=60)
+    store.check_and_increment("y", limit=1, window=60)
+    assert len(store) == 2
+
+
+def test_hash_key_is_deterministic_and_does_not_leak_secret():
+    key = "apikey:sk-live-supersecret"
+    hashed = _hash_key(key)
+
+    assert hashed == _hash_key(key)  # deterministic
+    assert "supersecret" not in hashed
+    assert len(hashed) == 12


### PR DESCRIPTION
## Summary

`stg` に積まれた変更を `main` に反映する。

### 新しいコミット
- `fix(ci): report status instead of failing when Actions cannot open PR` (5fc1045a)
- `fix: docker build cache + event-driven runner + rate limit cleanup (#100, #101, #102, #109)` (f4646b45)

### 含まれる issue 対応
- **#101** .dockerignore 追加
- **#109** Dockerfile BuildKit cache mount + COPY 順序最適化
- **#100** ProcessRunner を asyncio.Condition 駆動に変更（50ms polling → event-driven）
- **#102** rate limit store の定期 cleanup + API key のハッシュ化ログ
- **#99** 調査の結果、コードは問題なしと判定して close
- CI の merge-to-main を PR 自動化方式に変更し、GITHUB_TOKEN 制限で失敗しないよう status report に改修

## Test plan

- [x] 487/487 unit tests pass (5件新規追加)
- [x] `docker build` cold/warm 両方成功（warm 時 context 819B）
- [x] API コンテナ再起動後 /ready → 200, 2/2 HOT servers ready
- [x] stg 側 CI (test-python) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)