### PR TITLE
stg -> main: precache backoff, stream bridge cleanup, zod validation

### DIFF
--- a/apps/airis-commands/package.json
+++ b/apps/airis-commands/package.json
@@ -12,7 +12,8 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.28.0"
+    "@modelcontextprotocol/sdk": "^1.28.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/apps/airis-commands/src/index.ts
+++ b/apps/airis-commands/src/index.ts
@@ -16,6 +16,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import * as fs from "fs/promises";
 import * as path from "path";
+import { z, ZodError, ZodSchema } from "zod";
 
 import {
   MCP_MAPPINGS,
@@ -36,25 +37,39 @@ const CONFIG_PATH = process.env.MCP_CONFIG_PATH || "/app/mcp-config.json";
 const PROFILES_DIR = process.env.PROFILES_DIR || "/app/profiles";
 const WORKSPACE_DIR = process.env.HOST_WORKSPACE_DIR || "/workspace/host";
 
-interface AddServerArgs {
-  name: string;
-  command: string;
-  args?: string[];
-  env?: Record<string, string>;
-  enabled?: boolean;
-}
+// ── Tool argument schemas (issue #106) ───────────────────────────────────
+// Using Zod instead of `as unknown as T` so that invalid inputs surface as a
+// clear validation error instead of undefined-access crashes at runtime.
 
-interface ServerNameArgs {
-  server_name: string;
-}
+const AddServerArgsSchema = z.object({
+  name: z.string().min(1, "name must be a non-empty string"),
+  command: z.string().min(1, "command must be a non-empty string"),
+  args: z.array(z.string()).optional(),
+  env: z.record(z.string()).optional(),
+  enabled: z.boolean().optional(),
+});
 
-interface ProfileNameArgs {
-  profile_name: string;
-}
+const ServerNameArgsSchema = z.object({
+  server_name: z.string().min(1, "server_name must be a non-empty string"),
+});
 
-interface DetectArgs {
-  path?: string;
-  autoAdd?: boolean;
+const ProfileNameArgsSchema = z.object({
+  profile_name: z.string().min(1, "profile_name must be a non-empty string"),
+});
+
+const DetectArgsSchema = z.object({
+  path: z.string().optional(),
+  autoAdd: z.boolean().optional(),
+});
+
+function parseArgs<T>(schema: ZodSchema<T>, raw: unknown, toolName: string): T {
+  const result = schema.safeParse(raw ?? {});
+  if (!result.success) {
+    const issue = result.error.issues[0];
+    const path = issue.path.join(".") || "<root>";
+    throw new Error(`Invalid arguments for ${toolName}: ${path}: ${issue.message}`);
+  }
+  return result.data;
 }
 
 const server = new Server(
@@ -190,7 +205,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   try {
     switch (name) {
       case "airis_config_add_server": {
-        const { name: serverName, command, args: cmdArgs, env, enabled } = args as unknown as AddServerArgs;
+        const { name: serverName, command, args: cmdArgs, env, enabled } =
+          parseArgs(AddServerArgsSchema, args, "airis_config_add_server");
 
         await addServer(CONFIG_PATH, serverName, {
           command,
@@ -210,7 +226,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case "airis_config_remove_server": {
-        const serverName = (args as unknown as ServerNameArgs).server_name;
+        const { server_name: serverName } = parseArgs(
+          ServerNameArgsSchema,
+          args,
+          "airis_config_remove_server",
+        );
         await removeServer(CONFIG_PATH, serverName);
 
         return {
@@ -224,7 +244,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case "airis_profile_save": {
-        const profileName = (args as unknown as ProfileNameArgs).profile_name;
+        const { profile_name: profileName } = parseArgs(
+          ProfileNameArgsSchema,
+          args,
+          "airis_profile_save",
+        );
         await saveProfile(CONFIG_PATH, PROFILES_DIR, profileName);
 
         return {
@@ -238,7 +262,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case "airis_profile_load": {
-        const profileName = (args as unknown as ProfileNameArgs).profile_name;
+        const { profile_name: profileName } = parseArgs(
+          ProfileNameArgsSchema,
+          args,
+          "airis_profile_load",
+        );
         await loadProfile(CONFIG_PATH, PROFILES_DIR, profileName);
 
         return {
@@ -271,7 +299,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case "airis_mcp_detect": {
-        const { path: repoPath = WORKSPACE_DIR, autoAdd = false } = (args ?? {}) as unknown as DetectArgs;
+        const parsed = parseArgs(DetectArgsSchema, args, "airis_mcp_detect");
+        const repoPath = parsed.path ?? WORKSPACE_DIR;
+        const autoAdd = parsed.autoAdd ?? false;
         const config = await readConfig(CONFIG_PATH);
 
         const detected: Array<{

--- a/apps/api/src/app/api/endpoints/mcp_proxy.py
+++ b/apps/api/src/app/api/endpoints/mcp_proxy.py
@@ -82,9 +82,10 @@ import time as _time_module
 
 _session_response_queues: dict[str, tuple[asyncio.Queue, float]] = {}
 _session_queues_lock = asyncio.Lock()
-_SESSION_QUEUE_TTL_SECONDS = 3600  # 1 hour
+_SESSION_QUEUE_TTL_SECONDS = 600  # 10 minutes — shorter than before to bound memory
 _stream_bridge_sessions: dict[str, "StreamBridgeSession"] = {}
 _stream_bridge_lock = asyncio.Lock()
+_STREAM_BRIDGE_TTL_SECONDS = 900  # 15 minutes idle before a bridge is torn down
 
 
 async def get_response_queue(session_id: str) -> asyncio.Queue:
@@ -130,6 +131,38 @@ async def cleanup_stale_queues() -> int:
 def get_session_queue_count() -> int:
     """Get current number of session queues (for monitoring)."""
     return len(_session_response_queues)
+
+
+async def cleanup_stale_stream_bridges() -> int:
+    """Tear down StreamBridgeSession entries that have been idle for too long.
+
+    Each bridge holds an open httpx.AsyncClient and an SSE reader task, so
+    a leaked bridge costs a file descriptor, a task, and a queue. Idle ones
+    need to be closed proactively — clients may disconnect without sending
+    a DELETE and a long-running gateway would otherwise accumulate them.
+    """
+    now = _time_module.monotonic()
+    threshold = now - _STREAM_BRIDGE_TTL_SECONDS
+    to_close: list[str] = []
+    async with _stream_bridge_lock:
+        for sid, session in _stream_bridge_sessions.items():
+            if session.closed or session.last_activity < threshold:
+                to_close.append(sid)
+
+    removed = 0
+    for sid in to_close:
+        try:
+            await _close_stream_bridge_session(sid)
+            removed += 1
+            logger.info("Cleaned up stale stream bridge session: %s", sid)
+        except Exception as exc:  # noqa: BLE001 — best-effort cleanup
+            logger.warning("Error closing stale stream bridge %s: %s", sid, exc)
+    return removed
+
+
+def get_stream_bridge_count() -> int:
+    """Number of live StreamBridgeSession entries (for monitoring)."""
+    return len(_stream_bridge_sessions)
 
 
 class DescriptionMode:
@@ -321,6 +354,11 @@ class StreamBridgeSession:
     closed: bool = False
     reader_task: Optional[asyncio.Task] = None
     created_at: float = field(default_factory=_time_module.monotonic)
+    last_activity: float = field(default_factory=_time_module.monotonic)
+
+    def touch(self) -> None:
+        """Record that the client or backend just used this session."""
+        self.last_activity = _time_module.monotonic()
 
     async def close(self) -> None:
         if self.closed:
@@ -502,6 +540,8 @@ async def _send_via_stream_bridge(
             status_code=400,
             media_type="application/json",
         )
+
+    session.touch()
 
     # The Docker Gateway can briefly reject the first POST after the SSE stream
     # opens with "session not found". Let the backend session settle first.

--- a/apps/api/src/app/core/config.py
+++ b/apps/api/src/app/core/config.py
@@ -1,6 +1,43 @@
+import logging
 import os
 from pydantic_settings import BaseSettings
 from pathlib import Path
+
+
+_env_logger = logging.getLogger("airis.config")
+
+
+class InvalidEnvVar(RuntimeError):
+    """Raised when an environment variable cannot be parsed into its target type."""
+
+
+def _env_int(name: str, default: int) -> int:
+    """Parse an int env var, logging a clear error and raising on bad input.
+
+    Empty or unset -> default. Non-numeric -> InvalidEnvVar so the bad value
+    surfaces at import time instead of as an opaque ValueError deep in a
+    startup trace.
+    """
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        return int(raw)
+    except ValueError as exc:
+        _env_logger.error("Invalid %s=%r (expected int): %s", name, raw, exc)
+        raise InvalidEnvVar(f"{name}={raw!r} is not a valid int") from exc
+
+
+def _env_float(name: str, default: float) -> float:
+    """Parse a float env var, logging a clear error and raising on bad input."""
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        return float(raw)
+    except ValueError as exc:
+        _env_logger.error("Invalid %s=%r (expected float): %s", name, raw, exc)
+        raise InvalidEnvVar(f"{name}={raw!r} is not a valid float") from exc
 
 DEFAULT_PROJECT_ROOT = Path(
     os.getenv(
@@ -75,7 +112,7 @@ class Settings(BaseSettings):
     # Tool Call Timeout (seconds)
     # Fail-safe timeout for MCP tool calls to prevent Claude Code from hanging indefinitely.
     # Applies to ProcessManager tool calls and Docker Gateway proxy requests.
-    TOOL_CALL_TIMEOUT: float = float(os.getenv("TOOL_CALL_TIMEOUT", "90"))
+    TOOL_CALL_TIMEOUT: float = _env_float("TOOL_CALL_TIMEOUT", 90.0)
 
     # CORS
     CORS_ORIGINS: list[str] = []
@@ -152,8 +189,8 @@ def validate_environment() -> list[str]:
         )
 
     # Validate rate limits
-    rate_limit_ip = int(os.getenv("RATE_LIMIT_PER_IP", "100"))
-    rate_limit_key = int(os.getenv("RATE_LIMIT_PER_API_KEY", "1000"))
+    rate_limit_ip = _env_int("RATE_LIMIT_PER_IP", 100)
+    rate_limit_key = _env_int("RATE_LIMIT_PER_API_KEY", 1000)
     if rate_limit_ip > rate_limit_key:
         warnings.append(
             f"RATE_LIMIT_PER_IP ({rate_limit_ip}) > RATE_LIMIT_PER_API_KEY ({rate_limit_key}). "

--- a/apps/api/src/app/main.py
+++ b/apps/api/src/app/main.py
@@ -53,6 +53,33 @@ def _spawn_background_task(
     return task
 
 
+async def _wait_for_docker_gateway(timeout: float = 30.0) -> bool:
+    """Poll the Docker Gateway /health endpoint until it responds 200.
+
+    Uses exponential backoff so warm restarts recover quickly (~100ms) and
+    cold starts do not flood the gateway with requests.
+
+    Returns True on success, False on timeout.
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    delay = 0.1
+    gateway_url = MCP_GATEWAY_URL.rstrip("/")
+
+    async with httpx.AsyncClient(timeout=1.0) as client:
+        while loop.time() < deadline:
+            try:
+                resp = await client.get(f"{gateway_url}/health")
+                if resp.status_code == 200:
+                    return True
+            except (httpx.ConnectError, httpx.ReadTimeout, httpx.HTTPError):
+                pass
+            await asyncio.sleep(delay)
+            delay = min(delay * 1.5, 1.0)
+
+    return False
+
+
 async def _precache_docker_gateway_tools():
     """
     Background task to pre-cache Docker Gateway tools at startup.
@@ -66,8 +93,10 @@ async def _precache_docker_gateway_tools():
     """
     import json
 
-    # Wait for Gateway to be fully ready
-    await asyncio.sleep(2.0)
+    # Wait for the Gateway to accept /health instead of sleeping blindly.
+    if not await _wait_for_docker_gateway(timeout=30.0):
+        logger.warning("[Startup] Docker Gateway did not become ready in 30s; skipping precache")
+        return
 
     gateway_url = MCP_GATEWAY_URL.rstrip("/")
     logger.info(f"[Startup] Pre-caching Docker Gateway tools...")
@@ -148,12 +177,19 @@ async def _precache_docker_gateway_tools():
                         if data_str.startswith("{"):
                             try:
                                 data = json.loads(data_str)
-                                if data.get("id") == 2 and "result" in data:
-                                    docker_tools = data["result"].get("tools", [])
-                                    logger.info(f"[Startup] Received {len(docker_tools)} tools from Gateway")
-                                    break
-                            except json.JSONDecodeError:
-                                pass
+                            except json.JSONDecodeError as e:
+                                # Surface the failure so stuck precache is diagnosable.
+                                logger.warning(
+                                    "[Startup] Discarding non-JSON SSE data from Gateway: %s (raw=%s)",
+                                    e,
+                                    data_str[:200],
+                                )
+                                continue
+
+                            if data.get("id") == 2 and "result" in data:
+                                docker_tools = data["result"].get("tools", [])
+                                logger.info(f"[Startup] Received {len(docker_tools)} tools from Gateway")
+                                break
 
                 # Cancel sender if still running
                 if sender_task and not sender_task.done():
@@ -244,16 +280,23 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.error(f"ProcessManager init failed: {e}")
 
-    # Start periodic cleanup of stale session queues
+    # Start periodic cleanup of stale session queues and stream bridges.
     async def _periodic_queue_cleanup():
         while True:
             await asyncio.sleep(600)  # every 10 minutes
             try:
-                removed = await mcp_proxy.cleanup_stale_queues()
-                if removed > 0:
-                    logger.info(f"Cleaned up {removed} stale session queue(s)")
+                removed_queues = await mcp_proxy.cleanup_stale_queues()
+                if removed_queues > 0:
+                    logger.info(f"Cleaned up {removed_queues} stale session queue(s)")
             except Exception as e:
                 logger.warning(f"Session queue cleanup error: {e}")
+
+            try:
+                removed_bridges = await mcp_proxy.cleanup_stale_stream_bridges()
+                if removed_bridges > 0:
+                    logger.info(f"Cleaned up {removed_bridges} stale stream bridge(s)")
+            except Exception as e:
+                logger.warning(f"Stream bridge cleanup error: {e}")
 
     cleanup_task = _spawn_background_task(
         _periodic_queue_cleanup(),

--- a/apps/api/tests/unit/test_config_env_parsers.py
+++ b/apps/api/tests/unit/test_config_env_parsers.py
@@ -1,0 +1,65 @@
+"""Tests for _env_int/_env_float helpers (issue #107).
+
+These tests always look up the helpers via the live module because
+test_config.py and test_config_production.py may `importlib.reload` the
+config module between test files. Holding references imported at the top
+of this module would leave them pointing at a stale InvalidEnvVar class
+that the live module no longer raises.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.core import config as config_module
+
+
+def _helpers():
+    return (
+        config_module.InvalidEnvVar,
+        config_module._env_int,
+        config_module._env_float,
+    )
+
+
+def test_env_int_returns_default_when_missing(monkeypatch):
+    _, env_int, _ = _helpers()
+    monkeypatch.delenv("SOME_INT", raising=False)
+    assert env_int("SOME_INT", 42) == 42
+
+
+def test_env_int_returns_default_when_empty(monkeypatch):
+    _, env_int, _ = _helpers()
+    monkeypatch.setenv("SOME_INT", "")
+    assert env_int("SOME_INT", 7) == 7
+
+
+def test_env_int_parses_value(monkeypatch):
+    _, env_int, _ = _helpers()
+    monkeypatch.setenv("SOME_INT", "99")
+    assert env_int("SOME_INT", 0) == 99
+
+
+def test_env_int_raises_on_garbage(monkeypatch):
+    invalid_cls, env_int, _ = _helpers()
+    monkeypatch.setenv("SOME_INT", "not-a-number")
+    with pytest.raises(invalid_cls, match="SOME_INT"):
+        env_int("SOME_INT", 0)
+
+
+def test_env_float_parses_value(monkeypatch):
+    _, _, env_float = _helpers()
+    monkeypatch.setenv("SOME_FLOAT", "1.5")
+    assert env_float("SOME_FLOAT", 0.0) == 1.5
+
+
+def test_env_float_raises_on_garbage(monkeypatch):
+    invalid_cls, _, env_float = _helpers()
+    monkeypatch.setenv("SOME_FLOAT", "abc")
+    with pytest.raises(invalid_cls, match="SOME_FLOAT"):
+        env_float("SOME_FLOAT", 0.0)
+
+
+def test_env_float_returns_default_when_missing(monkeypatch):
+    _, _, env_float = _helpers()
+    monkeypatch.delenv("SOME_FLOAT", raising=False)
+    assert env_float("SOME_FLOAT", 9.0) == 9.0

--- a/apps/api/tests/unit/test_stream_bridge_cleanup.py
+++ b/apps/api/tests/unit/test_stream_bridge_cleanup.py
@@ -1,0 +1,72 @@
+"""Tests for stream bridge session cleanup (issue #111)."""
+from __future__ import annotations
+
+import time as _time
+
+import pytest
+
+from app.api.endpoints import mcp_proxy
+
+
+class _FakeBridge:
+    """Minimal stand-in for StreamBridgeSession.
+
+    Only exposes the attributes that cleanup_stale_stream_bridges touches,
+    plus an async close() that records the call.
+    """
+
+    def __init__(self, public_session_id: str, last_activity: float, closed: bool = False):
+        self.public_session_id = public_session_id
+        self.last_activity = last_activity
+        self.closed = closed
+        self._close_calls = 0
+
+    async def close(self) -> None:
+        self._close_calls += 1
+        self.closed = True
+
+
+@pytest.fixture(autouse=True)
+def clear_bridge_state():
+    mcp_proxy._stream_bridge_sessions.clear()
+    yield
+    mcp_proxy._stream_bridge_sessions.clear()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_removes_idle_bridge(monkeypatch):
+    now = _time.monotonic()
+    fresh = _FakeBridge("fresh", last_activity=now)
+    stale = _FakeBridge("stale", last_activity=now - 10_000)
+    mcp_proxy._stream_bridge_sessions["fresh"] = fresh  # type: ignore[assignment]
+    mcp_proxy._stream_bridge_sessions["stale"] = stale  # type: ignore[assignment]
+
+    removed = await mcp_proxy.cleanup_stale_stream_bridges()
+
+    assert removed == 1
+    assert "stale" not in mcp_proxy._stream_bridge_sessions
+    assert "fresh" in mcp_proxy._stream_bridge_sessions
+    assert stale._close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_cleanup_removes_already_closed_bridge():
+    now = _time.monotonic()
+    closed = _FakeBridge("closed", last_activity=now, closed=True)
+    mcp_proxy._stream_bridge_sessions["closed"] = closed  # type: ignore[assignment]
+
+    removed = await mcp_proxy.cleanup_stale_stream_bridges()
+
+    assert removed == 1
+    assert "closed" not in mcp_proxy._stream_bridge_sessions
+
+
+@pytest.mark.asyncio
+async def test_cleanup_noop_on_empty_store():
+    assert await mcp_proxy.cleanup_stale_stream_bridges() == 0
+
+
+def test_get_stream_bridge_count_tracks_dict_size():
+    assert mcp_proxy.get_stream_bridge_count() == 0
+    mcp_proxy._stream_bridge_sessions["a"] = _FakeBridge("a", 0.0)  # type: ignore[assignment]
+    assert mcp_proxy.get_stream_bridge_count() == 1

--- a/apps/gateway-control/package.json
+++ b/apps/gateway-control/package.json
@@ -12,7 +12,8 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.28.0"
+    "@modelcontextprotocol/sdk": "^1.28.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/apps/gateway-control/src/index.ts
+++ b/apps/gateway-control/src/index.ts
@@ -18,8 +18,30 @@ import {
   ListPromptsRequestSchema,
   GetPromptRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
+import { z, ZodSchema } from "zod";
 
 const API_URL = process.env.API_URL || "http://localhost:9400";
+
+// Tool argument schemas (issue #106). See airis-commands/src/index.ts for
+// the rationale: runtime-validated inputs instead of unchecked type casts.
+
+const ServerNameRequiredSchema = z.object({
+  server_name: z.string().min(1, "server_name must be a non-empty string"),
+});
+
+const ServerNameOptionalSchema = z.object({
+  server_name: z.string().min(1).optional(),
+});
+
+function parseArgs<T>(schema: ZodSchema<T>, raw: unknown, toolName: string): T {
+  const result = schema.safeParse(raw ?? {});
+  if (!result.success) {
+    const issue = result.error.issues[0];
+    const path = issue.path.join(".") || "<root>";
+    throw new Error(`Invalid arguments for ${toolName}: ${path}: ${issue.message}`);
+  }
+  return result.data;
+}
 
 interface ServerStatus {
   name: string;
@@ -51,10 +73,6 @@ interface ToolsStatusResponse {
     active_clients?: number;
     total_events_sent?: number;
   };
-}
-
-interface ServerArgs {
-  server_name?: string;
 }
 
 async function fetchApi<T = unknown>(path: string, options?: RequestInit): Promise<T> {
@@ -193,10 +211,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case "gateway_enable_server": {
-        const serverName = (args as ServerArgs | undefined)?.server_name;
-        if (!serverName) {
-          throw new Error("server_name is required");
-        }
+        const { server_name: serverName } = parseArgs(
+          ServerNameRequiredSchema,
+          args,
+          "gateway_enable_server",
+        );
 
         const result = await fetchApi<{ state: string }>(`/process/servers/${serverName}/enable`, {
           method: "POST",
@@ -213,10 +232,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case "gateway_disable_server": {
-        const serverName = (args as ServerArgs | undefined)?.server_name;
-        if (!serverName) {
-          throw new Error("server_name is required");
-        }
+        const { server_name: serverName } = parseArgs(
+          ServerNameRequiredSchema,
+          args,
+          "gateway_disable_server",
+        );
 
         const result = await fetchApi<{ state: string }>(`/process/servers/${serverName}/disable`, {
           method: "POST",
@@ -233,10 +253,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case "gateway_get_server_status": {
-        const serverName = (args as ServerArgs | undefined)?.server_name;
-        if (!serverName) {
-          throw new Error("server_name is required");
-        }
+        const { server_name: serverName } = parseArgs(
+          ServerNameRequiredSchema,
+          args,
+          "gateway_get_server_status",
+        );
 
         const result = await fetchApi<ServerStatus>(`/process/servers/${serverName}`);
 
@@ -251,7 +272,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case "gateway_list_tools": {
-        const serverName = (args as ServerArgs | undefined)?.server_name;
+        const { server_name: serverName } = parseArgs(
+          ServerNameOptionalSchema,
+          args,
+          "gateway_list_tools",
+        );
         const path = serverName
           ? `/process/tools?server=${serverName}`
           : "/process/tools";


### PR DESCRIPTION
## Summary

さらなる issue 対応を `main` に反映する。

### 含まれる issue
- **#103** `_precache_docker_gateway_tools` の `json.JSONDecodeError` を握りつぶさずログする
- **#108** Docker Gateway 起動待ちを `exponential backoff` + `/health` poll に変更（hardcoded sleep 削除）
- **#111** `StreamBridgeSession` に `last_activity` 追加、`cleanup_stale_stream_bridges()` を定期 cleanup タスクに追加
- **#107** `_env_int` / `_env_float` ヘルパーを導入し不正値で `InvalidEnvVar` を明示 raise
- **#106** `airis-commands` / `gateway-control` に `zod` を追加し、全ツール引数を `parseArgs(schema, args, name)` で検証
- **#104** クローズ（docstring 内のサンプルコードでした）

## Test plan

- [x] 498/498 Python unit tests pass（+11 件）
- [x] `airis-commands` vitest: 30/30 green
- [x] `gateway-control` vitest: 0 tests (passWithNoTests)
- [x] TS typecheck both packages green (zod 依存追加後)
- [x] Docker image build 3m42s success（BuildKit cache 効果）
- [x] API restart → /ready 200, 2/2 HOT servers ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)