### PR TITLE
stg -> main: pinning, npm standardisation, core tests, spec sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,10 @@ jobs:
       - name: Install dependencies
         run: |
           cd apps/${{ matrix.package }}
-          npm install
+          # npm ci enforces that package-lock.json is in sync with
+          # package.json so a developer who forgot to regenerate the
+          # lockfile fails the build instead of silently drifting.
+          npm ci
 
       - name: Run tests
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -79,5 +79,8 @@ Casks/
 # Binary artifacts
 mcp-publisher
 
-# Lock files (pnpm-lock managed per workspace)
+# Lock files — the TypeScript apps are standardised on npm (issue #81),
+# so we track package-lock.json and reject any stray pnpm-lock.yaml that
+# shows up from a developer running pnpm by accident.
 apps/*/pnpm-lock.yaml
+pnpm-lock.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,14 @@
-# syntax=docker/dockerfile:1.6
+# syntax=docker/dockerfile:1.7
+
+# NOTE: This file is NOT used by docker-compose.yml. The active build is
+# apps/api/Dockerfile. This multi-stage definition is retained for external
+# tooling (e.g. `docker build --target measurement`). Base image tags are
+# pinned (issue #77) so that whatever still consumes it is reproducible.
 
 ###########################################
 # API (FastAPI + uv + Alembic)
 ###########################################
-FROM python:3.12-slim AS api
+FROM python:3.12.13-slim-trixie AS api
 
 RUN pip install --no-cache-dir uv
 WORKDIR /app
@@ -25,7 +30,7 @@ ENTRYPOINT ["./entrypoint.sh"]
 ###########################################
 # Settings UI (Vite + pnpm + nginx)
 ###########################################
-FROM node:24-alpine AS settings-builder
+FROM node:24.9.0-alpine3.20 AS settings-builder
 
 RUN corepack enable && corepack prepare pnpm@latest --activate
 WORKDIR /monorepo
@@ -40,7 +45,7 @@ RUN pnpm install
 WORKDIR /monorepo/apps/settings
 RUN pnpm build
 
-FROM nginx:1.27-alpine AS settings
+FROM nginx:1.27.5-alpine AS settings
 ENV UI_PORT=5273 \
     API_PROXY_URL=http://api:9400
 
@@ -54,6 +59,8 @@ CMD ["sh", "-c", "envsubst '$$UI_PORT $$API_PROXY_URL' < /etc/nginx/templates/de
 ###########################################
 # Gateway (docker/mcp-gateway base)
 ###########################################
+# NOTE: docker/mcp-gateway does not publish versioned tags on Docker Hub, so
+# we track :latest here. Pin by digest once upstream tags are available.
 FROM docker/mcp-gateway:latest AS gateway
 
 LABEL maintainer="AIRIS MCP Gateway Team"
@@ -66,7 +73,7 @@ HEALTHCHECK --interval=30s --timeout=10s --retries=3 --start-period=40s \
 ###########################################
 # MindBase MCP Server Builder
 ###########################################
-FROM node:24-alpine AS mindbase-builder
+FROM node:24.9.0-alpine3.20 AS mindbase-builder
 
 RUN corepack enable && corepack prepare pnpm@latest --activate
 WORKDIR /app
@@ -76,7 +83,7 @@ CMD ["sh", "-c", "pnpm install && pnpm build && sleep infinity"]
 ###########################################
 # Gateway Control MCP Server Builder
 ###########################################
-FROM node:24-alpine AS gateway-control-builder
+FROM node:24.9.0-alpine3.20 AS gateway-control-builder
 
 WORKDIR /app
 CMD ["sh", "-c", "npm install && npm run build && sleep infinity"]
@@ -85,7 +92,7 @@ CMD ["sh", "-c", "npm install && npm run build && sleep infinity"]
 ###########################################
 # Token Measurement
 ###########################################
-FROM python:3.12-slim AS measurement
+FROM python:3.12.13-slim-trixie AS measurement
 
 WORKDIR /app
 COPY tools/measurement/requirements.txt .

--- a/apps/airis-commands/package-lock.json
+++ b/apps/airis-commands/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "@airis/commands",
-  "version": "1.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@airis/commands",
-      "version": "1.0.0",
+      "version": "2.1.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.28.0"
+        "@modelcontextprotocol/sdk": "^1.28.0",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -2699,9 +2700,9 @@
       "license": "ISC"
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/apps/airis-commands/package.json
+++ b/apps/airis-commands/package.json
@@ -4,6 +4,7 @@
   "description": "AIRIS utility commands MCP server",
   "type": "module",
   "main": "dist/index.js",
+  "packageManager": "npm@10.9.7",
   "scripts": {
     "build": "esbuild src/index.ts --bundle --platform=node --format=esm --outfile=dist/index.js --banner:js=\"import { createRequire } from 'module'; const require = createRequire(import.meta.url);\"",
     "typecheck": "tsc --noEmit",

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -2,7 +2,11 @@
 # FastAPI Hybrid MCP Gateway
 # Supports both Docker MCP Gateway proxy and direct uvx/npx process management
 # Includes browser automation support for Playwright and chrome-devtools MCP servers
-FROM python:3.12-slim
+#
+# Base image is pinned to a specific patch version (issue #77). Refresh this
+# tag via `docker pull python:3.12.13-slim-trixie` and verify `airis test`
+# before bumping.
+FROM python:3.12.13-slim-trixie
 
 # Keep apt lists across layers in a BuildKit cache so repeated builds don't
 # re-download the same packages. rm -rf is NOT needed because the cache mount
@@ -91,12 +95,13 @@ WORKDIR /app
 # reuse the cached npm install layer.
 #
 # Build gateway-control
+# Use `npm ci` so the lockfile must be in sync (issue #81).
 COPY apps/gateway-control/package*.json /tmp/gateway-control/
 COPY apps/gateway-control/tsconfig.json /tmp/gateway-control/
 COPY apps/gateway-control/src /tmp/gateway-control/src/
 RUN --mount=type=cache,target=/root/.npm,sharing=locked \
     cd /tmp/gateway-control \
-    && npm install \
+    && npm ci \
     && npm run build \
     && mkdir -p /app/gateway-control \
     && cp dist/index.js /app/gateway-control/ \
@@ -108,7 +113,7 @@ COPY apps/airis-commands/tsconfig.json /tmp/airis-commands/
 COPY apps/airis-commands/src /tmp/airis-commands/src/
 RUN --mount=type=cache,target=/root/.npm,sharing=locked \
     cd /tmp/airis-commands \
-    && npm install \
+    && npm ci \
     && npm run build \
     && mkdir -p /app/airis-commands \
     && cp dist/index.js /app/airis-commands/ \

--- a/apps/api/tests/unit/test_crypto.py
+++ b/apps/api/tests/unit/test_crypto.py
@@ -1,0 +1,91 @@
+"""Tests for AESEncryption (issue #85)."""
+from __future__ import annotations
+
+import base64
+import os
+import secrets
+
+import pytest
+
+from app.core.crypto import AESEncryption, load_default_cipher
+
+
+def _hex_key(size: int) -> str:
+    return secrets.token_bytes(size).hex()
+
+
+def test_rejects_empty_key():
+    with pytest.raises(RuntimeError, match="MASTER_KEY_HEX must be set"):
+        AESEncryption("")
+
+
+def test_rejects_none_key():
+    with pytest.raises(RuntimeError, match="MASTER_KEY_HEX must be set"):
+        AESEncryption(None)
+
+
+def test_rejects_invalid_encoding():
+    with pytest.raises(RuntimeError, match="hex encoded or urlsafe base64"):
+        AESEncryption("!!! not hex !!!")
+
+
+@pytest.mark.parametrize("size", [16, 24, 32])
+def test_accepts_valid_hex_key_sizes(size):
+    cipher = AESEncryption(_hex_key(size))
+    encrypted = cipher.encrypt(b"hello")
+    assert cipher.decrypt(encrypted) == b"hello"
+
+
+def test_rejects_wrong_key_size():
+    with pytest.raises(RuntimeError, match="128/192/256-bit"):
+        AESEncryption(secrets.token_bytes(20).hex())
+
+
+def test_accepts_urlsafe_base64_key():
+    raw = secrets.token_bytes(32)
+    b64 = base64.urlsafe_b64encode(raw).decode()
+    cipher = AESEncryption(b64)
+    assert cipher.decrypt(cipher.encrypt(b"roundtrip")) == b"roundtrip"
+
+
+def test_encrypt_produces_distinct_nonces():
+    cipher = AESEncryption(_hex_key(32))
+    a = cipher.encrypt(b"same plaintext")
+    b = cipher.encrypt(b"same plaintext")
+    assert a != b  # Different nonce → different ciphertext
+
+
+def test_decrypt_rejects_truncated_blob():
+    cipher = AESEncryption(_hex_key(32))
+    with pytest.raises(ValueError, match="too short"):
+        cipher.decrypt(b"\x00" * 5)
+
+
+def test_decrypt_detects_tamper():
+    cipher = AESEncryption(_hex_key(32))
+    blob = cipher.encrypt(b"do not tamper")
+    tampered = blob[:-1] + bytes([blob[-1] ^ 0xFF])
+    with pytest.raises(Exception):
+        cipher.decrypt(tampered)
+
+
+def test_load_default_cipher_prefers_master_key_hex(monkeypatch):
+    key = _hex_key(32)
+    monkeypatch.setenv("MASTER_KEY_HEX", key)
+    monkeypatch.delenv("ENCRYPTION_MASTER_KEY", raising=False)
+    cipher = load_default_cipher()
+    assert cipher.decrypt(cipher.encrypt(b"env")) == b"env"
+
+
+def test_load_default_cipher_falls_back_to_encryption_master_key(monkeypatch):
+    monkeypatch.delenv("MASTER_KEY_HEX", raising=False)
+    monkeypatch.setenv("ENCRYPTION_MASTER_KEY", _hex_key(32))
+    cipher = load_default_cipher()
+    assert cipher.decrypt(cipher.encrypt(b"fallback")) == b"fallback"
+
+
+def test_load_default_cipher_raises_without_either_env(monkeypatch):
+    monkeypatch.delenv("MASTER_KEY_HEX", raising=False)
+    monkeypatch.delenv("ENCRYPTION_MASTER_KEY", raising=False)
+    with pytest.raises(RuntimeError, match="MASTER_KEY_HEX must be set"):
+        load_default_cipher()

--- a/apps/api/tests/unit/test_registry.py
+++ b/apps/api/tests/unit/test_registry.py
@@ -1,0 +1,144 @@
+"""Tests for MCPRegistry (issue #85)."""
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.core.registry import MCPRegistry
+
+
+class _FakeCredentials:
+    """Minimal CredentialProvider stand-in."""
+
+    def __init__(self):
+        self._subscribers: list = []
+
+    def subscribe(self, callback):
+        self._subscribers.append(callback)
+
+    def notify(self, connector_id: str, ts: int = 0):
+        for cb in list(self._subscribers):
+            cb(connector_id, ts)
+
+
+class _FakeClient:
+    """Minimal connector client stand-in."""
+
+    def __init__(self, name: str):
+        self.name = name
+        self.reset_auth = MagicMock()
+        self.light_probe = AsyncMock()
+        self.invoke = AsyncMock(return_value={"value": 42})
+
+
+@pytest.fixture
+def registry_with_stub(monkeypatch):
+    creds = _FakeCredentials()
+    clients: dict[str, _FakeClient] = {}
+
+    def _build(connector_id: str, _creds):
+        clients[connector_id] = _FakeClient(connector_id)
+        return clients[connector_id]
+
+    monkeypatch.setattr(
+        "app.core.registry.build_connector",
+        _build,
+    )
+
+    registry = MCPRegistry(creds)
+    return registry, clients, creds
+
+
+@pytest.mark.asyncio
+async def test_invoke_returns_ok_on_success(registry_with_stub):
+    registry, clients, _ = registry_with_stub
+
+    result = await registry.invoke("stripe", "create", {"amount": 100})
+
+    assert result == {"ok": True, "data": {"value": 42}}
+    clients["stripe"].invoke.assert_awaited_once_with("create", {"amount": 100})
+
+
+@pytest.mark.asyncio
+async def test_invoke_records_failure_on_exception(registry_with_stub):
+    registry, clients, _ = registry_with_stub
+    clients_will_register = MCPRegistry  # noqa: F841 — ensure import still works
+    # Eagerly materialise the client so we can override its behaviour.
+    await registry._get("stripe")
+    clients["stripe"].invoke.side_effect = RuntimeError("boom")
+
+    result = await registry.invoke("stripe", "create", {})
+
+    assert result["ok"] is False
+    assert "boom" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_invoke_short_circuits_when_circuit_open(registry_with_stub):
+    registry, clients, _ = registry_with_stub
+    await registry._get("stripe")
+
+    # Force the circuit open.
+    registry._circuits["stripe"].record_failure()
+
+    result = await registry.invoke("stripe", "create", {})
+
+    assert result["ok"] is False
+    assert result["error"] == "CIRCUIT_OPEN"
+    assert "retryAt" in result
+    clients["stripe"].invoke.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_probe_records_success(registry_with_stub):
+    registry, clients, _ = registry_with_stub
+
+    assert await registry.probe("stripe") is True
+
+    clients["stripe"].light_probe.assert_awaited_once()
+    assert registry._circuits["stripe"].allow() is True
+
+
+@pytest.mark.asyncio
+async def test_probe_records_failure(registry_with_stub):
+    registry, clients, _ = registry_with_stub
+    await registry._get("stripe")
+    clients["stripe"].light_probe.side_effect = RuntimeError("unreachable")
+
+    assert await registry.probe("stripe") is False
+    # After a failure the circuit should be OPEN until the backoff elapses.
+    assert registry._circuits["stripe"].state.state == "OPEN"
+
+
+@pytest.mark.asyncio
+async def test_get_reuses_existing_client(registry_with_stub):
+    registry, clients, _ = registry_with_stub
+
+    client1, circuit1 = await registry._get("stripe")
+    client2, circuit2 = await registry._get("stripe")
+
+    assert client1 is client2
+    assert circuit1 is circuit2
+    assert len(clients) == 1
+
+
+@pytest.mark.asyncio
+async def test_credential_change_triggers_reset_and_half_open(registry_with_stub):
+    registry, clients, creds = registry_with_stub
+    await registry._get("stripe")
+    registry._circuits["stripe"].record_failure()  # OPEN
+
+    creds.notify("stripe", ts=123)
+
+    clients["stripe"].reset_auth.assert_called_once()
+    assert registry._circuits["stripe"].state.state == "HALF_OPEN"
+
+
+@pytest.mark.asyncio
+async def test_credential_change_without_existing_client_is_noop(registry_with_stub):
+    registry, _clients, creds = registry_with_stub
+
+    # Should not raise even though nothing has been materialised yet.
+    creds.notify("unknown-server")

--- a/apps/api/tests/unit/test_toolset_catalog.py
+++ b/apps/api/tests/unit/test_toolset_catalog.py
@@ -1,0 +1,143 @@
+"""Tests for build_toolset_index (issue #85)."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import patch
+
+from app.core.toolset_catalog import build_toolset_index
+
+
+@dataclass
+class _FakeConfig:
+    tools_index: list[dict]
+
+
+def _stub_seed_catalog(seed: dict | None = None):
+    return patch("app.core.toolset_catalog._load_seed_catalog", return_value=seed or {})
+
+
+def test_empty_configs_return_empty_index():
+    with _stub_seed_catalog():
+        assert build_toolset_index({}) == {}
+
+
+def test_server_without_tools_index_is_skipped():
+    configs = {"lonely": _FakeConfig(tools_index=[])}
+    with _stub_seed_catalog():
+        assert build_toolset_index(configs) == {}
+
+
+def test_seed_catalog_populates_named_toolset():
+    configs = {
+        "stripe": _FakeConfig(
+            tools_index=[
+                {"name": "create_payment"},
+                {"name": "list_charges"},
+                {"name": "refund"},
+            ]
+        )
+    }
+    seed = {
+        "stripe": {
+            "toolsets": {
+                "payments": {
+                    "summary": "Payment operations",
+                    "tools": ["create_payment", "refund"],
+                }
+            }
+        }
+    }
+    with _stub_seed_catalog(seed):
+        result = build_toolset_index(configs)
+
+    assert "stripe.payments" in result
+    payments = result["stripe.payments"]
+    assert payments.server == "stripe"
+    assert payments.name == "payments"
+    assert payments.summary == "Payment operations"
+    assert sorted(payments.tools) == ["create_payment", "refund"]
+
+
+def test_remaining_tools_fall_into_default_toolset():
+    configs = {
+        "stripe": _FakeConfig(
+            tools_index=[
+                {"name": "create_payment"},
+                {"name": "list_charges"},
+                {"name": "refund"},
+            ]
+        )
+    }
+    seed = {
+        "stripe": {
+            "toolsets": {
+                "payments": {
+                    "summary": "Payment operations",
+                    "tools": ["create_payment", "refund"],
+                }
+            }
+        }
+    }
+    with _stub_seed_catalog(seed):
+        result = build_toolset_index(configs)
+
+    assert "stripe.default" in result
+    default = result["stripe.default"]
+    assert default.tools == ["list_charges"]
+    assert default.summary == "Default capability slice for stripe"
+
+
+def test_server_with_no_seed_entry_gets_default_only():
+    configs = {
+        "github": _FakeConfig(
+            tools_index=[{"name": "get_issue"}, {"name": "list_prs"}]
+        )
+    }
+    with _stub_seed_catalog({}):
+        result = build_toolset_index(configs)
+
+    assert list(result.keys()) == ["github.default"]
+    assert result["github.default"].tools == ["get_issue", "list_prs"]
+
+
+def test_tools_outside_indexed_list_are_ignored_from_seed():
+    configs = {
+        "stripe": _FakeConfig(tools_index=[{"name": "create_payment"}])
+    }
+    seed = {
+        "stripe": {
+            "toolsets": {
+                "payments": {
+                    "summary": "Payment operations",
+                    # ghost_tool doesn't exist in tools_index — should be dropped.
+                    "tools": ["create_payment", "ghost_tool"],
+                }
+            }
+        }
+    }
+    with _stub_seed_catalog(seed):
+        result = build_toolset_index(configs)
+
+    assert result["stripe.payments"].tools == ["create_payment"]
+
+
+def test_toolsets_with_no_matching_tools_are_skipped():
+    configs = {
+        "stripe": _FakeConfig(tools_index=[{"name": "create_payment"}])
+    }
+    seed = {
+        "stripe": {
+            "toolsets": {
+                "refunds": {"summary": "refund-only", "tools": ["issue_refund"]},
+            }
+        }
+    }
+    with _stub_seed_catalog(seed):
+        result = build_toolset_index(configs)
+
+    # "refunds" has no overlap with tools_index so it should not be emitted,
+    # but the single remaining tool should land in default.
+    assert "stripe.refunds" not in result
+    assert "stripe.default" in result
+    assert result["stripe.default"].tools == ["create_payment"]

--- a/apps/gateway-control/package-lock.json
+++ b/apps/gateway-control/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "@airis/gateway-control",
-  "version": "1.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@airis/gateway-control",
-      "version": "1.0.0",
+      "version": "2.1.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.28.0"
+        "@modelcontextprotocol/sdk": "^1.28.0",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -2699,9 +2700,9 @@
       "license": "ISC"
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/apps/gateway-control/package.json
+++ b/apps/gateway-control/package.json
@@ -4,6 +4,7 @@
   "description": "MCP server for controlling AIRIS MCP Gateway",
   "type": "module",
   "main": "dist/index.js",
+  "packageManager": "npm@10.9.7",
   "scripts": {
     "build": "esbuild src/index.ts --bundle --platform=node --format=esm --outfile=dist/index.js --banner:js=\"import { createRequire } from 'module'; const require = createRequire(import.meta.url);\"",
     "typecheck": "tsc --noEmit",

--- a/docs/specs/2026-04-04-directive-workflow-engine-design.md
+++ b/docs/specs/2026-04-04-directive-workflow-engine-design.md
@@ -1,5 +1,7 @@
 # Directive Workflow Engine 設計仕様書
 
+> **Status (2026-04-13):** この文書は設計段階のドラフトを保存した履歴で、実装は意図的に簡素化されました。実装と一致する部分だけを参照し、詳細は末尾の **Implementation delta** セクションを優先してください (#76)。
+
 ## コンテキスト
 
 AIRIS MCP Gateway の Dynamic MCP はツールトークンを ~98% 削減済み（42k → ~600 tokens）。しかし LLM は接続された MCP ツールを自発的に使わない。現在の `behavior_compiler.py` は「WHEN X → Use Y」という提案を生成するだけで、LLM はこれを無視できる。
@@ -302,3 +304,70 @@ will result in incorrect implementations based on outdated knowledge.
 - `steps` フィールドで airis-route 連携
 - ランタイムメトリクス: LLM がどのワークフローに従ったかを追跡
 - ワークフロー有効性スコアリング（ツール呼び出しパターンから算出）
+
+---
+
+## Implementation delta (2026-04-13)
+
+上記の仕様は YAGNI を適用した簡素化版として実装されました。実装とのズレを以下に記録します (#76)。この節と実装の内容が一致していれば、上の仕様本文は「当初の意図」として読み、実際の挙動を確認するときはこの節を最優先してください。
+
+### WorkflowConfig (5 フィールドに簡素化)
+
+`apps/api/src/app/core/workflow_loader.py` で実装されている dataclass は次のとおり。
+
+```python
+@dataclass
+class WorkflowConfig:
+    name: str               # kebab-case 識別子
+    compile_to: str         # 注入先を識別するターゲット種別 (e.g. "mcp_instructions")
+    priority: str           # "high" | "medium" | "low"
+    text: str               # instructions に注入する確定テキスト
+    servers: list[str] = field(default_factory=list)
+```
+
+仕様本文との差分:
+
+| 仕様 (当初)                           | 実装                     | 備考 |
+|---------------------------------------|---------------------------|------|
+| `description`                         | 削除                      | 説明はファイルコメントで賄う |
+| `max_tokens`                          | 削除                      | トークン見積もり機構ごと廃止 |
+| `trigger`                             | 削除                      | ランタイムマッチングをしないので不要 |
+| `compile_to` = 注入テキスト本体       | `compile_to` = ターゲット種別 | 注入テキスト本体は `text` フィールドに分離 |
+| (新設) `text`                         | `text` が本文             | `compile_to: "mcp_instructions"` と組で使う |
+
+### バリデーション
+
+`validate_workflow()` は廃止され、モジュール内部の `_validate()` が同等のチェックを行います。対象:
+
+- `name` が非空かつ kebab-case
+- `priority` が {high, medium, low} のいずれか
+- `compile_to` が非空
+- `text` が非空
+
+**トークン数のバリデーションと `max_tokens` 閾値チェックは実装されていません**。関連して `estimate_tokens()` / トークンバジェット制御 (`~800 tokens` の上限、`medium`/`low` のスキップ) も存在しません。現状は workflow ファイルを書くときに手動でサイズに気をつける運用です。
+
+### コンパイルフロー
+
+`apps/api/src/app/core/behavior_compiler.py` にある関数は次の 1 つだけです。
+
+```python
+def _compile_workflow_texts(workflows: list[WorkflowConfig]) -> str:
+    ...
+```
+
+仕様で挙げていた `_compile_workflow_section` / `_compile_fallback_section` / `_compile_server_list` の 3 分割は実装されず、`_compile_workflow_texts()` が workflows を単純連結して返します。フォールバック指令 (airis-find 誘導) は `_BASE_INSTRUCTIONS` 側の固定文言として埋め込まれており、実行時に `mcp-config.json` から自動生成するサーバー一覧 (`_compile_server_list`) も廃止されています。
+
+### 実装済みファイル
+
+- `apps/api/src/app/core/workflow_loader.py` (loader + validator)
+- `apps/api/src/app/core/behavior_compiler.py` (`_compile_workflow_texts`)
+- `workflows/implement-feature.yaml`, `workflows/web-research.yaml`, `workflows/data-query.yaml`, `workflows/proactive-usage.yaml`, `workflows/tool-routing.yaml`
+- `apps/api/tests/unit/test_workflow_loader.py`, `test_behavior_compiler.py`
+
+### 将来スペック復活のトリガー
+
+次のいずれかが必要になった時点で、本仕様書の対応セクションを復活させるか別 issue で再設計します。
+
+- workflow の自動トランケート / 優先度ベースのバジェット制御が実運用で必要になった
+- 複数プロジェクトが同じ Gateway を共有して project-local override が必要になった
+- instructions のサイズが実測で肥大化し始めた (`~1500 tokens` 近辺)


### PR DESCRIPTION
## Summary

残りの中優先度 issue をまとめて `main` に反映する。

### 含まれる issue
- **#77** Dockerfile base images をパッチバージョンで固定
- **#81** TypeScript apps を npm に統一（`npm ci` + `packageManager` + lockfile 再生成）
- **#85** core modules (crypto / registry / toolset_catalog) にユニットテストを追加
- **#76** workflow-engine design spec に Implementation delta セクションを追加
- **#112** コード読み直しで対応済みと判断し close

## Test plan
- [x] 527/527 Python unit tests pass (+29: crypto 14, registry 8, toolset_catalog 7)
- [x] airis-commands vitest 30/30 green
- [x] `npm ci` both packages clean (regenerated lockfiles include zod)
- [x] Docker image build 3m10s success（BuildKit cache + pinned base）
- [x] API restart → /ready 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)