### PR TITLE
stg -> main: override hono transitive deps + sync main

### DIFF
--- a/apps/airis-commands/package-lock.json
+++ b/apps/airis-commands/package-lock.json
@@ -461,9 +461,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -1683,9 +1683,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.9",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
-      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/apps/airis-commands/package.json
+++ b/apps/airis-commands/package.json
@@ -21,5 +21,9 @@
     "esbuild": "^0.27.1",
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"
+  },
+  "overrides": {
+    "hono": "^4.12.12",
+    "@hono/node-server": "^1.19.14"
   }
 }

--- a/apps/gateway-control/package-lock.json
+++ b/apps/gateway-control/package-lock.json
@@ -461,9 +461,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -1683,9 +1683,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.9",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
-      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/apps/gateway-control/package.json
+++ b/apps/gateway-control/package.json
@@ -21,5 +21,9 @@
     "esbuild": "^0.27.1",
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"
+  },
+  "overrides": {
+    "hono": "^4.12.12",
+    "@hono/node-server": "^1.19.14"
   }
 }


### PR DESCRIPTION
## Summary

PR #96 のマージで高深刻度の vite CVE は解消したが、dependabot が残りの 12 件の **medium** 警告として hono 4.12.9 / @hono/node-server 1.19.11 の transitive を指していた。これらは @modelcontextprotocol/sdk@1.28.0 経由のため、`overrides` で pinned patched version に差し替えた。

## Changes
- `apps/airis-commands/package.json` と `apps/gateway-control/package.json` に overrides:
  - `hono: ^4.12.12`
  - `@hono/node-server: ^1.19.14`
- 両 package-lock.json を再生成
- `npm audit` 両 package で **0 vulnerabilities**
- `chore: sync stg with main (PR #96 vite 7.3.1 -> 7.3.2)` も含む（前コミット）

## Test plan
- [x] 527/527 Python unit tests pass
- [x] airis-commands vitest 30/30 green
- [x] Docker build success
- [x] `npm ls hono` → `4.12.12 overridden` in both packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)