### PR TITLE
refactor(airis-commands): rename airis-monorepo → airis-workspace

### DIFF
--- a/apps/airis-commands/src/index.ts
+++ b/apps/airis-commands/src/index.ts
@@ -350,6 +350,25 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           // No requirements.txt
         }
 
+        // Scan manifest.toml (Airis workspace)
+        try {
+          const manifestPath = path.join(repoPath, "manifest.toml");
+          await fs.access(manifestPath);
+          const airisMapping = MCP_MAPPINGS["airis-workspace"];
+          if (!detected.find(d => d.name === "airis-workspace")) {
+            detected.push({
+              name: "airis-workspace",
+              reason: "Found manifest.toml",
+              mcp: airisMapping.mcp,
+              description: airisMapping.description,
+              envRequired: airisMapping.envRequired,
+              alreadyExists: !!config.mcpServers["airis-workspace"],
+            });
+          }
+        } catch {
+          // No manifest.toml
+        }
+
         if (detected.length === 0) {
           return {
             content: [{

--- a/apps/airis-commands/src/lib.ts
+++ b/apps/airis-commands/src/lib.ts
@@ -109,6 +109,16 @@ export const MCP_MAPPINGS: Record<string, McpMapping> = {
     envRequired: [],
     description: "Browser automation",
   },
+  "airis-workspace": {
+    packages: [],
+    detect: ["manifest.toml"],
+    mcp: "airis-workspace",
+    command: "uvx",
+    args: ["--from", "git+https://github.com/agiletec-inc/airis-agent", "airis-workspace-mcp"],
+    env: {},
+    envRequired: [],
+    description: "Airis workspace manager (manifest.toml source of truth)",
+  },
 };
 
 // ── Pure Functions ──

--- a/apps/api/tests/unit/test_background_tasks_retained.py
+++ b/apps/api/tests/unit/test_background_tasks_retained.py
@@ -1,0 +1,120 @@
+"""
+Regression test for issue #110: module-level asyncio.create_task references
+not retained (GC risk).
+
+Python's asyncio.create_task() only holds a weak reference to the task from
+the event loop. If the caller drops its reference to the returned Task, a
+garbage collection cycle can collect it mid-execution, causing the coroutine
+to stop running silently. cfd32ec0 introduced `_background_tasks: set` in
+app.main to hold strong references for the lifetime of each task.
+
+These tests exercise the real `_spawn_background_task` helper against a real
+event loop — no mocks. They verify:
+
+1. A task spawned via the helper is present in `_background_tasks` while it
+   is running.
+2. The task is removed from `_background_tasks` after it completes (so the
+   set does not leak tasks forever).
+3. The GC cannot collect the task even when the caller throws away the
+   returned reference — because the module-level set still holds it.
+"""
+from __future__ import annotations
+
+import asyncio
+import gc
+
+import pytest
+
+from app.main import _background_tasks, _spawn_background_task
+
+
+@pytest.fixture(autouse=True)
+def clear_background_tasks():
+    _background_tasks.clear()
+    yield
+    _background_tasks.clear()
+
+
+@pytest.mark.asyncio
+async def test_spawn_background_task_adds_to_set():
+    async def _worker():
+        await asyncio.sleep(0.05)
+        return "done"
+
+    task = _spawn_background_task(_worker(), name="test_worker")
+    assert task in _background_tasks
+    assert len(_background_tasks) == 1
+
+    result = await task
+    assert result == "done"
+
+
+@pytest.mark.asyncio
+async def test_spawn_background_task_discards_after_completion():
+    async def _worker():
+        return 42
+
+    task = _spawn_background_task(_worker(), name="test_worker")
+    await task
+    # done_callback runs on the next event loop iteration; yield control so it
+    # can fire before we assert.
+    await asyncio.sleep(0)
+    assert task not in _background_tasks
+    assert len(_background_tasks) == 0
+
+
+@pytest.mark.asyncio
+async def test_background_task_survives_gc_without_caller_reference():
+    """The whole point of the set: if the caller drops its reference, the task
+    must still run to completion. Without the strong reference in
+    _background_tasks, gc.collect() could finalize the task mid-flight.
+    """
+    completion_marker: list[bool] = []
+
+    async def _worker():
+        # Give GC a chance to run before we finish.
+        await asyncio.sleep(0.05)
+        completion_marker.append(True)
+
+    # Spawn and immediately discard the caller-side reference.
+    _spawn_background_task(_worker(), name="gc_test_worker")
+
+    # Trigger GC aggressively while the task is still in flight.
+    gc.collect()
+    await asyncio.sleep(0.01)
+    gc.collect()
+
+    # Wait for the task to finish. We recover it via the module-level set; if
+    # GC had collected it, the set would be empty and this would fail.
+    assert _background_tasks, "task was dropped before completion — GC risk"
+    task = next(iter(_background_tasks))
+    await task
+
+    assert completion_marker == [True]
+
+
+@pytest.mark.asyncio
+async def test_on_error_callback_receives_task_on_failure():
+    """The on_error callback hook is how the lifespan wires up error
+    reporting for precache etc. Verify it fires with the task as its arg.
+    """
+    captured: list[asyncio.Task] = []
+
+    def _on_error(task: asyncio.Task):
+        captured.append(task)
+
+    async def _worker():
+        raise RuntimeError("boom")
+
+    task = _spawn_background_task(
+        _worker(),
+        name="failing_worker",
+        on_error=_on_error,
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await task
+
+    # done_callback fires on the next loop iteration.
+    await asyncio.sleep(0)
+    assert captured == [task]

--- a/apps/api/tests/unit/test_dockerfile_cache_mounts.py
+++ b/apps/api/tests/unit/test_dockerfile_cache_mounts.py
@@ -1,0 +1,105 @@
+"""
+Regression test for issue #109: Dockerfile rebuilds TypeScript apps without
+cache mounts.
+
+f4646b45 added BuildKit cache mounts for apt, pip/uv, and npm, and reordered
+package.json/tsconfig to be COPYed before src/ so source-only changes reuse
+the cached layer. If any of those mounts are removed, warm builds regress
+from seconds to minutes.
+
+This is a static guard over apps/api/Dockerfile:
+- `# syntax=docker/dockerfile:1.x` header must be present (BuildKit required).
+- At least one `--mount=type=cache,target=/var/cache/apt` (apt layer).
+- At least one `--mount=type=cache,target=/root/.cache/uv` (Python deps).
+- At least two `--mount=type=cache,target=/root/.npm` (one per TS app build).
+- For each TS app, `COPY package*.json` must appear BEFORE `COPY .../src`.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+DOCKERFILE = REPO_ROOT / "apps" / "api" / "Dockerfile"
+
+TS_APPS = ["gateway-control", "airis-commands"]
+
+# CI runs pytest from a full repo checkout; inside the api container only
+# apps/api/src is available, so the Dockerfile path does not resolve. Skip
+# the module so the Docker-internal smoke run stays green; CI is the
+# authoritative gate.
+if not DOCKERFILE.exists():
+    pytest.skip(
+        f"Dockerfile not reachable from {DOCKERFILE} — likely running inside "
+        "the api container, skipping. CI on a full repo checkout provides "
+        "the real gate.",
+        allow_module_level=True,
+    )
+
+
+def _dockerfile_lines() -> list[str]:
+    return DOCKERFILE.read_text(encoding="utf-8").splitlines()
+
+
+def test_dockerfile_exists():
+    assert DOCKERFILE.is_file(), f"{DOCKERFILE} is missing"
+
+
+def test_dockerfile_has_buildkit_syntax_header():
+    lines = _dockerfile_lines()
+    # Header must be the very first line (Docker requires this for BuildKit
+    # features like --mount=type=cache to be recognised).
+    assert lines, "Dockerfile is empty"
+    assert re.match(r"^# syntax=docker/dockerfile:1\.\d", lines[0]), (
+        "Dockerfile is missing the `# syntax=docker/dockerfile:1.x` header; "
+        "BuildKit cache mounts will be ignored without it (issue #109)."
+    )
+
+
+def test_dockerfile_has_apt_cache_mount():
+    text = DOCKERFILE.read_text(encoding="utf-8")
+    assert "--mount=type=cache,target=/var/cache/apt" in text, (
+        "apt cache mount missing from Dockerfile (issue #109)."
+    )
+
+
+def test_dockerfile_has_uv_cache_mount():
+    text = DOCKERFILE.read_text(encoding="utf-8")
+    assert "--mount=type=cache,target=/root/.cache/uv" in text, (
+        "uv cache mount missing from Dockerfile — Python dep installs will "
+        "not reuse the cache on warm builds (issue #109)."
+    )
+
+
+def test_dockerfile_has_npm_cache_mounts_for_each_ts_app():
+    text = DOCKERFILE.read_text(encoding="utf-8")
+    npm_mount_count = text.count("--mount=type=cache,target=/root/.npm")
+    assert npm_mount_count >= len(TS_APPS), (
+        f"Expected at least {len(TS_APPS)} `--mount=type=cache,target=/root/.npm` "
+        f"directives (one per TS app build), found {npm_mount_count} (issue #109)."
+    )
+
+
+def test_dockerfile_copies_package_json_before_src_for_each_ts_app():
+    """package.json/tsconfig must be COPYed BEFORE src/ so that source-only
+    changes reuse the cached `npm ci` layer. If src/ is copied first, every
+    .ts edit invalidates the install layer and rebuilds from scratch."""
+    text = DOCKERFILE.read_text(encoding="utf-8")
+    for app in TS_APPS:
+        pkg_match = re.search(rf"COPY\s+apps/{re.escape(app)}/package\*\.json", text)
+        src_match = re.search(rf"COPY\s+apps/{re.escape(app)}/src\b", text)
+        assert pkg_match, (
+            f"Missing `COPY apps/{app}/package*.json ...` in Dockerfile "
+            f"(issue #109)."
+        )
+        assert src_match, (
+            f"Missing `COPY apps/{app}/src ...` in Dockerfile (issue #109)."
+        )
+        assert pkg_match.start() < src_match.start(), (
+            f"apps/{app}/package*.json must be COPYed before apps/{app}/src "
+            f"so that source-only changes reuse the cached `npm ci` layer "
+            f"(issue #109). Current order will invalidate the cache on every "
+            f"TypeScript edit."
+        )

--- a/apps/api/tests/unit/test_dockerignore_regression.py
+++ b/apps/api/tests/unit/test_dockerignore_regression.py
@@ -1,0 +1,57 @@
+"""
+Regression test for issue #101: missing .dockerignore inflates build context.
+
+f4646b45 added a root .dockerignore. If someone deletes it or drops one of the
+critical exclusions, the Docker build context balloons (minutes of upload on
+warm builds, gigabytes of node_modules pushed to the daemon). This test is a
+static guard: it asserts the file exists and contains every exclusion the fix
+added.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+# apps/api/tests/unit/ -> apps/api/tests -> apps/api -> apps -> repo root
+REPO_ROOT = Path(__file__).resolve().parents[4]
+DOCKERIGNORE = REPO_ROOT / ".dockerignore"
+
+# CI runs pytest from a full repo checkout, so .dockerignore is reachable.
+# Inside the api container the repo is not mounted (only apps/api is COPYed),
+# so these tests must skip — the CI run is the authoritative gate.
+if not DOCKERIGNORE.exists():
+    pytest.skip(
+        f".dockerignore not reachable from {DOCKERIGNORE} — likely running "
+        "inside the api container, skipping. CI on a full repo checkout "
+        "provides the real gate.",
+        allow_module_level=True,
+    )
+
+REQUIRED_PATTERNS = [
+    ".git/",
+    "**/__pycache__/",
+    "**/.venv/",
+    "**/node_modules/",
+    "**/.pytest_cache/",
+    ".env",
+]
+
+
+def test_dockerignore_exists():
+    assert DOCKERIGNORE.is_file(), (
+        f"{DOCKERIGNORE} is missing. .dockerignore was added in f4646b45 to "
+        "keep .git, node_modules, and caches out of the Docker build context "
+        "(issue #101). Do not delete it."
+    )
+
+
+@pytest.mark.parametrize("pattern", REQUIRED_PATTERNS)
+def test_dockerignore_contains_required_pattern(pattern: str):
+    content = DOCKERIGNORE.read_text(encoding="utf-8")
+    lines = {line.strip() for line in content.splitlines() if line.strip() and not line.strip().startswith("#")}
+    assert pattern in lines, (
+        f"{pattern!r} is missing from .dockerignore. Without it the Docker "
+        "build context will include files that should never be shipped (see "
+        "issue #101)."
+    )

--- a/apps/api/tests/unit/test_no_deprecated_asyncio.py
+++ b/apps/api/tests/unit/test_no_deprecated_asyncio.py
@@ -1,0 +1,88 @@
+"""
+Regression test for issue #98: deprecated asyncio.get_event_loop() usage.
+
+Python 3.10+ emits DeprecationWarning when asyncio.get_event_loop() is called
+without a running loop, and Python 3.12+ will raise. Inside coroutines we must
+use asyncio.get_running_loop() instead.
+
+This test statically scans the source tree with the `ast` module and fails if
+any `asyncio.get_event_loop()` call reappears. It is intentionally a static
+check (not a runtime check) because #98 is a code-style invariant: the fix is
+"do not write this call", not "handle it at runtime".
+"""
+import ast
+from pathlib import Path
+
+import pytest
+
+SRC_ROOT = Path(__file__).resolve().parents[2] / "src" / "app"
+
+
+def _iter_python_files(root: Path):
+    yield from root.rglob("*.py")
+
+
+def _find_get_event_loop_calls(tree: ast.AST) -> list[tuple[int, int]]:
+    """Return (lineno, col_offset) for every `asyncio.get_event_loop()` call."""
+    hits: list[tuple[int, int]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if (
+            isinstance(func, ast.Attribute)
+            and func.attr == "get_event_loop"
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "asyncio"
+        ):
+            hits.append((node.lineno, node.col_offset))
+    return hits
+
+
+def test_src_root_exists():
+    assert SRC_ROOT.is_dir(), f"expected source dir at {SRC_ROOT}"
+
+
+def test_no_deprecated_get_event_loop_in_source():
+    """Regression guard for issue #98.
+
+    Scans apps/api/src/app/ recursively and fails if any file contains a
+    literal `asyncio.get_event_loop()` call. Use `asyncio.get_running_loop()`
+    inside coroutines instead.
+    """
+    offenders: list[str] = []
+    repo_root = SRC_ROOT.parents[2]
+    for path in _iter_python_files(SRC_ROOT):
+        source = path.read_text(encoding="utf-8")
+        try:
+            tree = ast.parse(source, filename=str(path))
+        except SyntaxError as exc:
+            pytest.fail(f"failed to parse {path}: {exc}")
+        hits = _find_get_event_loop_calls(tree)
+        for lineno, col in hits:
+            offenders.append(f"{path.relative_to(repo_root)}:{lineno}:{col}")
+
+    assert not offenders, (
+        "asyncio.get_event_loop() is deprecated in Python 3.10+ and will be "
+        "removed. Use asyncio.get_running_loop() inside coroutines. "
+        "Offending locations:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_regression_detector_itself_works(tmp_path: Path):
+    """Meta-test: make sure the AST matcher actually catches the bad pattern.
+
+    Without this, the real test could silently pass because the matcher is
+    broken rather than because the source is clean.
+    """
+    sample = tmp_path / "sample.py"
+    sample.write_text(
+        "import asyncio\n"
+        "async def f():\n"
+        "    loop = asyncio.get_event_loop()\n"
+        "    return loop\n",
+        encoding="utf-8",
+    )
+    tree = ast.parse(sample.read_text(encoding="utf-8"))
+    hits = _find_get_event_loop_calls(tree)
+    assert len(hits) == 1, f"matcher failed to find the bad call, hits={hits}"

--- a/apps/api/tests/unit/test_precache_error_handling.py
+++ b/apps/api/tests/unit/test_precache_error_handling.py
@@ -1,0 +1,162 @@
+"""
+Regression tests for issues #103 and #108 in the Docker Gateway precache
+startup path (apps/api/src/app/main.py).
+
+#103: swallowed json.JSONDecodeError hides Docker Gateway startup failures.
+    The precache loop must log the error (at WARNING or higher) instead of
+    silently continuing.
+
+#108: startup precache uses hardcoded sleeps instead of readiness polling.
+    The precache must call `_wait_for_docker_gateway()` (an exponential-
+    backoff /health poll) before issuing MCP requests, not `asyncio.sleep(2)`.
+
+Both checks are static — we cannot spin up a real Docker Gateway in unit
+tests — but they are expressed over the parsed AST of main.py, so any future
+edit that reintroduces the bugs will fail at CI time.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+SRC_ROOT = Path(__file__).resolve().parents[2] / "src" / "app"
+MAIN_PY = SRC_ROOT / "main.py"
+
+
+def _load_main_ast() -> ast.Module:
+    assert MAIN_PY.is_file(), f"{MAIN_PY} not found"
+    return ast.parse(MAIN_PY.read_text(encoding="utf-8"), filename=str(MAIN_PY))
+
+
+def _find_function(tree: ast.Module, name: str) -> ast.AsyncFunctionDef | ast.FunctionDef:
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and node.name == name:
+            return node
+    pytest.fail(f"function {name!r} not found in {MAIN_PY}")
+
+
+# ---------------------------------------------------------------------------
+# #108 — exponential-backoff /health poll instead of hardcoded sleep
+# ---------------------------------------------------------------------------
+
+
+def test_wait_for_docker_gateway_function_exists():
+    """#108: the exponential-backoff helper must be defined."""
+    tree = _load_main_ast()
+    fn = _find_function(tree, "_wait_for_docker_gateway")
+    assert isinstance(fn, ast.AsyncFunctionDef), (
+        "_wait_for_docker_gateway must be async"
+    )
+
+
+def test_precache_awaits_health_poll_not_hardcoded_sleep():
+    """#108: _precache_docker_gateway_tools must call _wait_for_docker_gateway
+    before any MCP traffic, and must not `await asyncio.sleep(<big literal>)`
+    as its gating step.
+    """
+    tree = _load_main_ast()
+    precache = _find_function(tree, "_precache_docker_gateway_tools")
+
+    # Must contain at least one call to _wait_for_docker_gateway.
+    health_poll_calls = [
+        node
+        for node in ast.walk(precache)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "_wait_for_docker_gateway"
+    ]
+    assert health_poll_calls, (
+        "_precache_docker_gateway_tools no longer calls "
+        "_wait_for_docker_gateway() — the old hardcoded sleep regression "
+        "has returned (issue #108)."
+    )
+
+    # Must NOT contain asyncio.sleep(N) where N >= 1 at the top of the
+    # function (i.e. before the first gateway call). We allow small delays
+    # inside the inner sender task (asyncio.sleep(0.3) for stream handshake)
+    # because those are part of the MCP protocol, not the outer gate.
+    #
+    # Strategy: inspect only statements that are direct children of the
+    # function body, before the first `async with` block (the body of which
+    # is the request loop). Any await asyncio.sleep(>=1) there is the bug.
+    for stmt in precache.body:
+        if isinstance(stmt, ast.AsyncWith):
+            # Reached the request loop — stop scanning.
+            break
+        for node in ast.walk(stmt):
+            if not (isinstance(node, ast.Await) and isinstance(node.value, ast.Call)):
+                continue
+            call = node.value
+            if not (
+                isinstance(call.func, ast.Attribute)
+                and call.func.attr == "sleep"
+                and isinstance(call.func.value, ast.Name)
+                and call.func.value.id == "asyncio"
+            ):
+                continue
+            if call.args and isinstance(call.args[0], ast.Constant):
+                value = call.args[0].value
+                if isinstance(value, (int, float)) and value >= 1:
+                    pytest.fail(
+                        f"_precache_docker_gateway_tools awaits "
+                        f"asyncio.sleep({value}) as a gating step before the "
+                        "MCP request loop. Replace it with "
+                        "_wait_for_docker_gateway() (issue #108)."
+                    )
+
+
+# ---------------------------------------------------------------------------
+# #103 — surface JSONDecodeError instead of silently swallowing
+# ---------------------------------------------------------------------------
+
+
+def test_precache_logs_jsondecodeerror_instead_of_swallowing():
+    """#103: the except json.JSONDecodeError handler inside the precache loop
+    must call logger.warning (or logger.error / logger.exception) — i.e. it
+    must not be a bare ``except ...: continue`` anymore.
+    """
+    tree = _load_main_ast()
+    precache = _find_function(tree, "_precache_docker_gateway_tools")
+
+    handlers = [
+        node
+        for node in ast.walk(precache)
+        if isinstance(node, ast.ExceptHandler)
+    ]
+
+    json_handlers = []
+    for handler in handlers:
+        exc_type = handler.type
+        # Match `except json.JSONDecodeError` and `except JSONDecodeError`.
+        is_match = False
+        if isinstance(exc_type, ast.Attribute) and exc_type.attr == "JSONDecodeError":
+            is_match = True
+        elif isinstance(exc_type, ast.Name) and exc_type.id == "JSONDecodeError":
+            is_match = True
+        if is_match:
+            json_handlers.append(handler)
+
+    assert json_handlers, (
+        "_precache_docker_gateway_tools no longer has an `except "
+        "json.JSONDecodeError` handler in its parsing loop. Either the loop "
+        "was removed or the exception is now caught too broadly — either "
+        "way #103 needs re-review."
+    )
+
+    for handler in json_handlers:
+        logs = [
+            node
+            for node in ast.walk(handler)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in {"warning", "error", "exception", "info"}
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "logger"
+        ]
+        assert logs, (
+            "except json.JSONDecodeError handler in _precache_docker_gateway_tools "
+            "silently swallows the error (no logger call). Log it so stuck "
+            "precache is diagnosable (issue #103)."
+        )

--- a/apps/api/tests/unit/test_process_runner_event_driven.py
+++ b/apps/api/tests/unit/test_process_runner_event_driven.py
@@ -1,0 +1,134 @@
+"""
+Regression test for issue #100: polling with asyncio.sleep(0.05) instead of
+event-driven in ensure_ready.
+
+f4646b45 replaced the 50ms polling loop with an asyncio.Condition. Any state
+transition goes through `_set_state()` which notifies waiters, so
+`ensure_ready_with_error` unblocks immediately when the process becomes READY
+instead of waiting up to 50ms for the next poll.
+
+These tests drive the real `ProcessRunner._state_cond` against a real event
+loop — no mocks. The trick: we do not actually spawn a subprocess (that would
+require a real MCP server). Instead we construct a ProcessRunner, then use
+`_set_state()` to drive the state machine from another task, proving the
+waiter unblocks on the condition's notify, not on a timer.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from app.core.process_runner import ProcessConfig, ProcessRunner, ProcessState
+
+
+def _make_runner(name: str = "test") -> ProcessRunner:
+    return ProcessRunner(
+        ProcessConfig(
+            name=name,
+            command="echo",
+            args=["hello"],
+        )
+    )
+
+
+def test_runner_has_asyncio_condition_for_state_transitions():
+    """Sanity: the Condition must be an asyncio.Condition, not a Lock or
+    Event. Using the wrong primitive would reintroduce polling (a Lock has no
+    notify_all) or miss notifications (Event.set is sticky)."""
+    runner = _make_runner()
+    assert isinstance(runner._state_cond, asyncio.Condition)
+
+
+@pytest.mark.asyncio
+async def test_set_state_notifies_waiters_immediately():
+    """A task waiting on the condition must unblock as soon as _set_state
+    fires — within a few milliseconds, not after the old 50ms poll window.
+    """
+    runner = _make_runner()
+    runner._state = ProcessState.RUNNING
+
+    async def waiter():
+        async with runner._state_cond:
+            # Mirrors the loop inside ensure_ready_with_error.
+            while runner._state != ProcessState.READY:
+                await runner._state_cond.wait()
+        return time.monotonic()
+
+    waiter_task = asyncio.create_task(waiter())
+    # Yield once so the waiter has a chance to enter wait().
+    await asyncio.sleep(0)
+
+    start = time.monotonic()
+    await runner._set_state(ProcessState.READY)
+    # Hard-cap the wait so a regressed _set_state that forgets to call
+    # notify_all() fails loudly instead of hanging the test runner forever.
+    try:
+        unblocked_at = await asyncio.wait_for(waiter_task, timeout=1.0)
+    except asyncio.TimeoutError:
+        waiter_task.cancel()
+        pytest.fail(
+            "waiter did not unblock within 1s after _set_state — "
+            "Condition.notify_all() probably missing (issue #100)."
+        )
+
+    elapsed = unblocked_at - start
+    # Pure event-driven unblock should take well under 20ms even on a loaded
+    # CI box. The old 50ms polling implementation could not beat ~50ms worst
+    # case, so a threshold of 25ms clearly distinguishes the two regimes.
+    assert elapsed < 0.025, (
+        f"waiter took {elapsed*1000:.1f}ms to unblock after _set_state; "
+        "likely regressed to polling instead of Condition.notify_all "
+        "(issue #100)."
+    )
+
+
+@pytest.mark.asyncio
+async def test_multiple_waiters_all_wake_on_state_change():
+    """notify_all must be used, not notify(), so every in-flight
+    ensure_ready_with_error call sees the transition. If someone changed it
+    to plain notify() only one waiter would unblock and the rest would hang
+    until the next transition."""
+    runner = _make_runner()
+    runner._state = ProcessState.RUNNING
+
+    woken = asyncio.Event()
+    wake_count = 0
+
+    async def waiter():
+        nonlocal wake_count
+        async with runner._state_cond:
+            while runner._state != ProcessState.READY:
+                await runner._state_cond.wait()
+            wake_count += 1
+            if wake_count == 3:
+                woken.set()
+
+    tasks = [asyncio.create_task(waiter()) for _ in range(3)]
+    await asyncio.sleep(0)  # let them all enter wait()
+
+    await runner._set_state(ProcessState.READY)
+
+    await asyncio.wait_for(woken.wait(), timeout=0.5)
+    for t in tasks:
+        await t
+    assert wake_count == 3
+
+
+@pytest.mark.asyncio
+async def test_ensure_ready_returns_immediately_when_already_ready():
+    """Fast path: if state is already READY, no waiting at all."""
+    runner = _make_runner()
+    runner._state = ProcessState.READY
+
+    start = time.monotonic()
+    ok, err = await runner.ensure_ready_with_error(timeout=1.0)
+    elapsed = time.monotonic() - start
+
+    assert ok is True
+    assert err is None
+    assert elapsed < 0.01, (
+        f"fast-path ensure_ready took {elapsed*1000:.1f}ms; it should return "
+        "before any condition wait."
+    )

--- a/apps/api/tests/unit/test_typescript_no_unsafe_cast.py
+++ b/apps/api/tests/unit/test_typescript_no_unsafe_cast.py
@@ -1,0 +1,93 @@
+"""
+Regression test for issue #106: TypeScript args use `as unknown as T`
+bypassing runtime validation.
+
+07dd06ce replaced every `as unknown as T` cast on incoming MCP tool arguments
+with zod validation in both TypeScript apps. If someone drops zod and goes
+back to unchecked casts, malformed tool-call payloads will crash the server
+with unhelpful undefined-access errors at runtime.
+
+This Python test is a cross-cutting guard over the two TypeScript apps.
+Running vitest from unit tests is not practical (different runtime, not
+available in the api container), so we:
+1. Assert `as unknown as` does NOT appear in src/index.ts for either app.
+2. Assert `zod` is imported in src/index.ts for either app.
+3. Assert `parseArgs(` (or an equivalent zod `.safeParse`/`.parse`) is used.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+TS_APPS = [
+    REPO_ROOT / "apps" / "airis-commands" / "src" / "index.ts",
+    REPO_ROOT / "apps" / "gateway-control" / "src" / "index.ts",
+]
+
+# Inside the api container only apps/api is COPYed, so the TS sources are
+# unreachable. CI checks out the full repo, where these paths resolve; that
+# is the authoritative gate.
+if not all(p.exists() for p in TS_APPS):
+    pytest.skip(
+        "TypeScript app sources not reachable — likely running inside the "
+        "api container, skipping. CI on a full repo checkout provides the "
+        "real gate.",
+        allow_module_level=True,
+    )
+
+
+@pytest.mark.parametrize("ts_file", TS_APPS, ids=lambda p: p.parent.parent.name)
+def test_ts_app_exists(ts_file: Path):
+    assert ts_file.is_file(), f"{ts_file} missing"
+
+
+@pytest.mark.parametrize("ts_file", TS_APPS, ids=lambda p: p.parent.parent.name)
+def test_ts_app_has_no_unsafe_cast(ts_file: Path):
+    """`as unknown as T` is the specific anti-pattern #106 called out.
+
+    We check for the substring `as unknown as` rather than a regex because
+    that is the exact form the commit removed, and any legitimate variant
+    should be challenged in code review.
+    """
+    content = ts_file.read_text(encoding="utf-8")
+    # Strip single-line comments before matching so a "// avoid `as unknown as`"
+    # note in the source doesn't trigger us.
+    stripped = re.sub(r"//[^\n]*", "", content)
+    assert "as unknown as" not in stripped, (
+        f"{ts_file.relative_to(REPO_ROOT)} contains `as unknown as` which "
+        "bypasses runtime validation (issue #106). Use zod instead."
+    )
+
+
+@pytest.mark.parametrize("ts_file", TS_APPS, ids=lambda p: p.parent.parent.name)
+def test_ts_app_imports_zod(ts_file: Path):
+    content = ts_file.read_text(encoding="utf-8")
+    # Accept both `import { z } from "zod"` and `import * as z from "zod"`.
+    assert re.search(r'from\s+["\']zod["\']', content), (
+        f"{ts_file.relative_to(REPO_ROOT)} does not import zod. MCP tool "
+        "arguments must be runtime-validated with zod (issue #106)."
+    )
+
+
+@pytest.mark.parametrize("ts_file", TS_APPS, ids=lambda p: p.parent.parent.name)
+def test_ts_app_actually_validates_arguments(ts_file: Path):
+    """Importing zod is not enough — it has to be called on incoming args.
+
+    Accept any of these zod validation shapes as evidence:
+    - `parseArgs(` (the shared helper added in 07dd06ce)
+    - `.safeParse(`
+    - `.parse(`
+    """
+    content = ts_file.read_text(encoding="utf-8")
+    has_validation = any(
+        marker in content
+        for marker in ("parseArgs(", ".safeParse(", ".parse(")
+    )
+    assert has_validation, (
+        f"{ts_file.relative_to(REPO_ROOT)} imports zod but never calls "
+        "parseArgs/.safeParse/.parse on tool arguments (issue #106)."
+    )


### PR DESCRIPTION
## Summary
- `MCP_MAPPINGS`の`airis-monorepo`キーを`airis-workspace`に変更
- commandを`airis mcp`から`uvx --from git+... airis-workspace-mcp`に更新
- manifest.toml検出ロジックのキー参照を統一

## Test plan
- [ ] `airis_mcp_detect`がmanifest.tomlのあるリポジトリで`airis-workspace`を提案することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)