### PR TITLE
feat: point airis-workspace mapping at local airis CLI

### DIFF
--- a/apps/airis-commands/src/lib.ts
+++ b/apps/airis-commands/src/lib.ts
@@ -113,11 +113,11 @@ export const MCP_MAPPINGS: Record<string, McpMapping> = {
     packages: [],
     detect: ["manifest.toml"],
     mcp: "airis-workspace",
-    command: "uvx",
-    args: ["--from", "git+https://github.com/agiletec-inc/airis-agent", "airis-workspace-mcp"],
+    command: "airis",
+    args: ["mcp"],
     env: {},
     envRequired: [],
-    description: "Airis workspace manager (manifest.toml source of truth)",
+    description: "Airis workspace manager (stdio MCP server exposed by the airis CLI)",
   },
 };
 


### PR DESCRIPTION
## Summary

- The `airis-workspace` entry in `MCP_MAPPINGS` referenced `uvx --from git+https://github.com/agiletec-inc/airis-agent airis-workspace-mcp`. That Python package was never published, so the mapping was effectively dead.
- The airis-workspace repo now ships an stdio MCP server directly inside the Rust binary (`airis mcp`). Swap the mapping to invoke that binary — no Python wrapper, no external dependency.
- Detection still triggers on `manifest.toml`; `airis_mcp_detect` will now suggest a working registration when it finds an airis workspace.

**Companion repo PR:** [agiletec-inc/airis-workspace feat/retire-init-cli-and-expand-mcp](https://github.com/agiletec-inc/airis-workspace/pull/new/feat/retire-init-cli-and-expand-mcp) — ships the MCP server and retires the redundant `airis init` CLI.

## Test plan

- [ ] `airis_mcp_detect` in a repo with `manifest.toml` proposes the new command/args shape
- [ ] After adding the server via `airis_config_add_server`, `airis-find workspace` surfaces `workspace_init`, `workspace_gen`, `workspace_verify`, etc.
- [ ] end-to-end: `workspace_init` → `manifest_apply` → `workspace_gen` via `airis-exec` against an empty project

🤖 Generated with [Claude Code](https://claude.com/claude-code)