### PR TITLE
fix: migrate manifest.toml to airis CLI schema (closes #127)

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -1,18 +1,30 @@
+version = 1
+mode = "docker-first"
+
+[project]
+id = "airis-mcp-gateway"
+description = "Hybrid MCP Multiplexer — Docker Gateway + process (uvx/npx) servers behind a unified Streamable HTTP / SSE transport"
+
 [workspace]
 name = "airis-mcp-gateway"
-version_file = "VERSION"
+package_manager = "pnpm@10"
+service = "api"
 
 [commands]
+# Minimal pre-push smoke test. Assumes `docker compose up -d` is already
+# running — verifies the gateway answers `/health` before letting a push
+# through. Full unit tests live in apps/api/tests and are run manually
+# or in CI; they need dev deps that are not baked into the prod image.
 test = "curl -sf http://localhost:9400/health"
 
-[packages]
-workspaces = ["apps/*"]
+[apps.api]
+path = "apps/api"
+type = "python"
 
-[[packages.app]]
-pattern = "apps/api"
+[apps.airis-commands]
+path = "apps/airis-commands"
+type = "node"
 
-[[packages.app]]
-pattern = "apps/airis-commands"
-
-[[packages.app]]
-pattern = "apps/gateway-control"
+[apps.gateway-control]
+path = "apps/gateway-control"
+type = "node"


### PR DESCRIPTION
## Summary
Migrates ``manifest.toml`` from the legacy ``[workspace]`` / ``[packages]`` shape to the current ``airis`` CLI schema so every workspace-aware subcommand — and the ``airis-managed`` pre-push hook that fronts ``airis test`` — stops failing with ``Manifest validation failed: project.id is required``.

## Why
- ``airis 2.6.0-dev`` rejects the old file. ``airis validate`` / ``doctor`` / ``gen`` / ``test`` all bail immediately.
- The pre-push PreToolUse hook runs ``airis test`` when ``manifest.toml`` is present and the CLI is installed, so every publish from this directory got blocked regardless of real test status. Already hit twice this week while shipping #122 and while archiving the dropped MCP V2.1 sketch.

## Changes
- ``version = 1`` + ``mode = "docker-first"`` at the top (required by the new schema).
- New ``[project]`` section with ``id = "airis-mcp-gateway"`` and a short description.
- ``[workspace]`` now declares ``package_manager`` and ``service = "api"`` so ``airis up`` / ``shell`` target the right container by default.
- Apps listed as ``[apps.api]`` / ``[apps.airis-commands]`` / ``[apps.gateway-control]`` with their ``path`` + ``type``.
- ``[commands].test`` kept at ``curl -sf /health`` — it's the pre-push smoke check. Full ``pytest`` runs still live in ``apps/api/tests`` and require dev deps that aren't in the prod image, so they aren't appropriate for a pre-push hook (tracked separately if we want to move them in-container).

## Verified
- ``airis validate all`` → all checks pass.
- ``airis doctor`` runs (flags unrelated hygiene: missing root ``package.json``, guards not installed, a couple of ``dist`` / ``.pnpm-store`` artifacts — out of scope here).
- ``airis test`` → ``{"status":"healthy"}``.

## Test plan
- [x] ``airis validate all`` green on this branch
- [x] ``airis test`` returns 200 when the stack is up
- [x] This PR's own push succeeded through the pre-push hook (previously blocked)
- [ ] Follow-up: decide whether to retire the legacy build tooling (``.tasks.d/``, ``Taskfile.yml``, ``devbox.*``, ``doppler.yaml``, ``install.sh``, ``server.json`` — all still sitting on ``main`` untouched). Closing #127 here leaves that decision open as its own ticket.

Closes #127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
