### PR TITLE
feat(api): tools/list_changed for Streamable HTTP (closes #124)

### DIFF
--- a/apps/api/src/app/api/endpoints/gateway_stream_bridge.py
+++ b/apps/api/src/app/api/endpoints/gateway_stream_bridge.py
@@ -38,7 +38,7 @@ from fastapi import Request, Response
 from ...core.behavior_compiler import compile_instructions
 from ...core.config import settings
 from ...core.logging import get_logger
-from .sse_protocol import parse_sse_json
+from .sse_protocol import format_sse_event, parse_sse_json
 from .tool_shaping import apply_prompts_merging, apply_schema_partitioning
 
 logger = get_logger(__name__)
@@ -370,6 +370,13 @@ async def send_via_stream_bridge(
             headers={stream_session_header_name(): session.public_session_id},
         )
 
+    # Buffer server-to-client notifications that arrive before the matching
+    # response. The MCP Streamable HTTP spec lets the server answer a single
+    # POST with either a JSON body or an SSE event stream; we use the SSE
+    # path only when there's at least one notification to deliver, so the
+    # fast path for routine tool calls stays plain JSON.
+    pending_notifications: list[dict] = []
+
     while True:
         try:
             payload = await asyncio.wait_for(
@@ -412,7 +419,29 @@ async def send_via_stream_bridge(
                 media_type="application/json",
             )
 
+        if (
+            isinstance(payload, dict)
+            and "method" in payload
+            and "id" not in payload
+            and get_response_message_id(payload) != expected_id
+        ):
+            # Server-to-client notification that is not the synthetic
+            # `notifications/initialized` bridge marker — buffer for SSE delivery.
+            pending_notifications.append(payload)
+            continue
+
         if expected_id is None or get_response_message_id(payload) == expected_id:
+            if pending_notifications:
+                body_parts = [
+                    format_sse_event(n) for n in pending_notifications
+                ]
+                body_parts.append(format_sse_event(payload))
+                return Response(
+                    content=b"".join(body_parts),
+                    status_code=200,
+                    media_type="text/event-stream",
+                    headers={stream_session_header_name(): session.public_session_id},
+                )
             return Response(
                 content=json.dumps(payload),
                 status_code=200,

--- a/apps/api/src/app/api/endpoints/tools_list_notifier.py
+++ b/apps/api/src/app/api/endpoints/tools_list_notifier.py
@@ -1,17 +1,27 @@
-"""Fan out `notifications/tools/list_changed` to connected SSE clients.
+"""Fan out `notifications/tools/list_changed` to connected clients.
 
 The ProcessManager fires a state-change event whenever a server is
 enabled, disabled, or idle-killed. This module subscribes to that
-event and pushes a JSON-RPC notification into every live SSE session
-queue so the client sees the HOT set shrink (or grow) without having
-to poll `tools/list`.
+event and pushes a JSON-RPC notification into every live client
+session so clients see the HOT set shrink (or grow) without polling
+``tools/list``.
 
-Streamable HTTP clients are not covered by this fan-out: their
-response queue is tied to an in-flight POST and the JSON-only shape of
-``send_via_stream_bridge`` cannot deliver a separate event. Those
-clients pick up the new set on the next tools/list they issue, which
-is frequent enough in practice (Claude Code, Gemini CLI) for the loss
-to be negligible.
+Two session kinds are fanned out to:
+
+* **Classic SSE sessions** — notifications are pushed into the
+  per-session ``asyncio.Queue`` kept in :mod:`session_queue`. The SSE
+  streaming loop drains the queue and writes each payload out as an
+  SSE event directly.
+* **Streamable HTTP bridges** — notifications are pushed into the
+  ``StreamBridgeSession.response_queue``. A waiting POST accumulates
+  them and, on the matching response, emits a ``text/event-stream``
+  response that carries the buffered notifications followed by the
+  request's actual result (see :func:`send_via_stream_bridge`).
+
+If no POST is in flight on a given bridge when a notification fires,
+it still sits in the queue and will be delivered on the next POST —
+the client therefore never misses a list change, only its arrival
+may be deferred a moment.
 """
 from __future__ import annotations
 
@@ -19,6 +29,7 @@ import asyncio
 
 from ...core.logging import get_logger
 from ...core.process_manager import get_process_manager
+from .gateway_stream_bridge import _stream_bridge_lock, _stream_bridge_sessions
 from .session_queue import _session_queues_lock, _session_response_queues
 
 logger = get_logger(__name__)
@@ -31,25 +42,34 @@ TOOLS_LIST_CHANGED_NOTIFICATION: dict = {
 
 
 async def fan_out_tools_list_changed(event: str, server_name: str) -> None:
-    """ProcessManager listener: push tools/list_changed to every SSE session."""
+    """ProcessManager listener: notify every live session of the HOT-set change."""
     async with _session_queues_lock:
-        queues = [entry[0] for entry in _session_response_queues.values()]
+        sse_queues = [entry[0] for entry in _session_response_queues.values()]
 
-    if not queues:
+    async with _stream_bridge_lock:
+        bridge_queues = [
+            session.response_queue
+            for session in _stream_bridge_sessions.values()
+            if not session.closed
+        ]
+
+    total = len(sse_queues) + len(bridge_queues)
+    if total == 0:
         logger.debug(
-            "tools/list_changed (%s on %s) — no SSE sessions to notify",
+            "tools/list_changed (%s on %s) — no sessions to notify",
             event,
             server_name,
         )
         return
 
     logger.info(
-        "Fanning out tools/list_changed (%s on %s) to %d SSE session(s)",
+        "Fanning out tools/list_changed (%s on %s) to %d SSE + %d stream-bridge session(s)",
         event,
         server_name,
-        len(queues),
+        len(sse_queues),
+        len(bridge_queues),
     )
-    for queue in queues:
+    for queue in sse_queues + bridge_queues:
         try:
             queue.put_nowait(TOOLS_LIST_CHANGED_NOTIFICATION)
         except asyncio.QueueFull:

--- a/apps/api/tests/unit/test_tools_list_notifier.py
+++ b/apps/api/tests/unit/test_tools_list_notifier.py
@@ -1,10 +1,12 @@
 """
-Regression test for the SSE fan-out of notifications/tools/list_changed.
+Regression tests for the fan-out of notifications/tools/list_changed.
 
-`fan_out_tools_list_changed` is registered with ProcessManager at
-startup. When a server leaves (or joins) the HOT set, every live SSE
-session queue must receive a properly-shaped JSON-RPC notification so
-the client re-requests tools/list.
+``fan_out_tools_list_changed`` is registered with ProcessManager at
+startup. When a server leaves (or joins) the HOT set every live
+client session must receive a properly-shaped JSON-RPC notification
+so the client re-requests tools/list. Two session kinds are covered:
+classic SSE sessions (``session_queue``) and Streamable HTTP bridges
+(``gateway_stream_bridge``).
 """
 from __future__ import annotations
 
@@ -12,7 +14,7 @@ import asyncio
 
 import pytest
 
-from app.api.endpoints import session_queue
+from app.api.endpoints import gateway_stream_bridge, session_queue
 from app.api.endpoints.tools_list_notifier import (
     TOOLS_LIST_CHANGED_NOTIFICATION,
     fan_out_tools_list_changed,
@@ -21,16 +23,27 @@ from app.api.endpoints.tools_list_notifier import (
 from app.core.process_manager import ProcessManager
 
 
+class _FakeBridge:
+    """Minimal stand-in for StreamBridgeSession for fan-out tests."""
+
+    def __init__(self, session_id: str, closed: bool = False) -> None:
+        self.public_session_id = session_id
+        self.closed = closed
+        self.response_queue: asyncio.Queue = asyncio.Queue()
+
+
 @pytest.fixture(autouse=True)
 def clean_session_queues():
-    """Reset the module-level session queue registry between tests."""
+    """Reset the module-level session registries between tests."""
     session_queue._session_response_queues.clear()
+    gateway_stream_bridge._stream_bridge_sessions.clear()
     yield
     session_queue._session_response_queues.clear()
+    gateway_stream_bridge._stream_bridge_sessions.clear()
 
 
 @pytest.mark.asyncio
-async def test_fan_out_pushes_notification_to_all_session_queues():
+async def test_fan_out_pushes_notification_to_all_sse_session_queues():
     q1 = await session_queue.get_response_queue("sess-1")
     q2 = await session_queue.get_response_queue("sess-2")
 
@@ -40,6 +53,49 @@ async def test_fan_out_pushes_notification_to_all_session_queues():
     assert q2.qsize() == 1
     assert q1.get_nowait() == TOOLS_LIST_CHANGED_NOTIFICATION
     assert q2.get_nowait() == TOOLS_LIST_CHANGED_NOTIFICATION
+
+
+@pytest.mark.asyncio
+async def test_fan_out_also_pushes_to_stream_bridge_sessions():
+    """Streamable HTTP bridges must receive the same notification shape."""
+    b1 = _FakeBridge("bridge-1")
+    b2 = _FakeBridge("bridge-2")
+    gateway_stream_bridge._stream_bridge_sessions["bridge-1"] = b1  # type: ignore[assignment]
+    gateway_stream_bridge._stream_bridge_sessions["bridge-2"] = b2  # type: ignore[assignment]
+
+    await fan_out_tools_list_changed("enabled", "context7")
+
+    assert b1.response_queue.qsize() == 1
+    assert b2.response_queue.qsize() == 1
+    assert b1.response_queue.get_nowait() == TOOLS_LIST_CHANGED_NOTIFICATION
+    assert b2.response_queue.get_nowait() == TOOLS_LIST_CHANGED_NOTIFICATION
+
+
+@pytest.mark.asyncio
+async def test_fan_out_skips_closed_stream_bridges():
+    """A bridge that has already been closed is not a valid delivery target."""
+    alive = _FakeBridge("alive")
+    dead = _FakeBridge("dead", closed=True)
+    gateway_stream_bridge._stream_bridge_sessions["alive"] = alive  # type: ignore[assignment]
+    gateway_stream_bridge._stream_bridge_sessions["dead"] = dead  # type: ignore[assignment]
+
+    await fan_out_tools_list_changed("disabled", "stripe")
+
+    assert alive.response_queue.qsize() == 1
+    assert dead.response_queue.qsize() == 0
+
+
+@pytest.mark.asyncio
+async def test_fan_out_delivers_to_mixed_sse_and_bridge_sessions():
+    """Both channel types must fire in a single call."""
+    sse = await session_queue.get_response_queue("sse-1")
+    bridge = _FakeBridge("bridge-1")
+    gateway_stream_bridge._stream_bridge_sessions["bridge-1"] = bridge  # type: ignore[assignment]
+
+    await fan_out_tools_list_changed("idle_killed", "supabase")
+
+    assert sse.qsize() == 1
+    assert bridge.response_queue.qsize() == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #124. v2.0 (PR #122) emitted tools/list_changed only over classic SSE; Streamable HTTP clients (Claude Code, Gemini CLI via /mcp/, Codex) were silently skipped. This PR buffers server-to-client notifications that arrive before the matching response id in send_via_stream_bridge and, when one or more are pending, answers with text/event-stream instead of application/json. Fast path preserved when no notification is queued. Unit suite 299 green; E2E verified notification + result delivered together as SSE events.