### PR TITLE
Fix dynamic mcp deprecation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ FastAPI-based MCP multiplexer that exposes many MCP servers (process + Docker Ga
 - **Streamable HTTP** at `http://localhost:9400/mcp/` — for Codex and Claude Code (recommended)
 - **SSE** at `http://localhost:9400/sse` — for Gemini CLI, Cursor, Windsurf
 
-Dynamic MCP mode (default) exposes only 3–4 meta-tools (`airis-find`, `airis-exec`, `airis-schema`) instead of 60+ raw tools, and lazily starts cold servers on first use.
+Dynamic MCP mode (default) exposes only 2 meta-tools (`airis-find`, `airis-schema`) instead of 60+ raw tools. COLD servers auto-discover and auto-enable on first native tool call — no router wrapper needed.
 
 Source of truth for server config: `mcp-config.json` (runtime) and `workflows/*.yaml` (compiled into MCP `initialize` instructions by `apps/api/src/app/core/behavior_compiler.py`).
 
@@ -37,7 +37,7 @@ The API in `apps/api/src/app/api/endpoints/` is split into focused modules:
 ### HOT/COLD server split
 
 - **HOT**: ProcessManager process servers (uvx/npx/airis) always listed in `tools/list` — pre-warmed at API startup, never idle-killed. Default HOT set: `context7`, `airis-mcp-gateway-control`, `airis-workspace`.
-- **COLD**: Docker Gateway backend servers — not listed directly; accessed via `airis-exec <server>:<tool>`, auto-enabled on first call.
+- **COLD**: Docker Gateway backend servers — not listed directly; auto-discovered via tools index on first native tool call, enabled on-demand.
 
 In DYNAMIC_MCP mode, `tools/list` returns only meta-tools + currently active HOT server tools. Full tool discovery goes through `airis-find`.
 
@@ -55,7 +55,7 @@ Note on JSON-RPC tolerance: airis-workspace emits `"error": null` alongside succ
 
 ## Dynamic MCP
 
-`DYNAMIC_MCP=true` (default) exposes 3 meta-tools: `airis-find` (discover), `airis-exec` (execute + auto-enable), `airis-schema` (get input schema). `META_TOOLS_MODE=full` adds `airis-confidence`, `airis-repo-index`, `airis-suggest`, `airis-route`. Disabled servers auto-enable when `airis-exec` calls them.
+`DYNAMIC_MCP=true` (default) exposes 2 meta-tools: `airis-find` (discover tools), `airis-schema` (get input schema). `META_TOOLS_MODE=full` adds `airis-confidence`, `airis-repo-index`, `airis-suggest`, `airis-route`. COLD servers auto-discover and auto-enable on first native tool call — no router wrapper needed.
 
 Instructions returned on `initialize` are compiled from `workflows/*.yaml` — **edit the YAML, not the Python**. Each workflow needs `name`, `compile_to: mcp_instructions`, `priority`, and a `text:` block. Missing `text` makes it emit literal `compile_to` values (bug: 2026-04-14).
 
@@ -64,12 +64,12 @@ Instructions returned on `initialize` are compiled from `workflows/*.yaml` — *
 When working in a project that uses this gateway, pick tools by this decision flow:
 
 ```
-Need official library docs?    → airis-exec context7:resolve-library-id → context7:query-docs
-Need current/external info?    → airis-exec tavily:tavily-search
-Database query or schema?      → airis-exec supabase:query
-Payment/billing?               → airis-exec stripe:*
-DNS/workers/KV?                → airis-exec cloudflare:*
-Figma/design?                  → airis-exec figma:*
+Need official library docs?    → context7:resolve-library-id → context7:query-docs
+Need current/external info?    → tavily:tavily-search
+Database query or schema?      → supabase:query
+Payment/billing?               → stripe:*
+DNS/workers/KV?                → cloudflare:*
+Figma/design?                  → figma:*
 Browser testing/screenshots?   → playwright-cli skill (host Chrome — NOT MCP playwright)
 File generation (docx/xlsx/…)? → claude-api plugin (host filesystem)
 TDD/debugging/planning?        → superpowers plugin

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Instructions returned on `initialize` are compiled from `workflows/*.yaml` — *
 When working in a project that uses this gateway, pick tools by this decision flow:
 
 ```
-Need official library docs?    → context7:resolve-library-id → context7:query-docs
+Need official library docs?    → context7:resolve-library-id → context7:get-library-docs
 Need current/external info?    → tavily:tavily-search
 Database query or schema?      → supabase:query
 Payment/billing?               → stripe:*

--- a/apps/api/src/app/api/endpoints/mcp_proxy.py
+++ b/apps/api/src/app/api/endpoints/mcp_proxy.py
@@ -18,31 +18,22 @@ The symbols that other modules and tests import from ``mcp_proxy`` (such as
 are re-exported at the bottom of this file so those call sites keep working.
 """
 
+import httpx
 from fastapi import APIRouter, Request, Response
 from fastapi.responses import StreamingResponse
-from typing import Any, AsyncGenerator, Dict, Optional
-import httpx
-import json
-import asyncio
-import time as _time_module
-from ...core.schema_partitioning import schema_partitioner
-from ...core.config import settings
-from ...core.protocol_logger import protocol_logger
-from ...core.process_manager import get_process_manager
-from ...core.dynamic_mcp import get_dynamic_mcp
-from ...core.behavior_compiler import compile_instructions
-from ...core.logging import get_logger
-from ...core.mcp_config_loader import ServerMode
 
+import asyncio
+import json
+from typing import Any, AsyncGenerator, Dict, Optional
+from .gateway_stream_bridge import (
+    STREAM_TIMEOUT,
+    delete_stream_bridge_session as _delete_stream_bridge_session,
+    send_via_stream_bridge as _send_via_stream_bridge,
+)
 # Responsibility-split modules. Imported with their public names so the rest
 # of this file reads as if the helpers were still local.
 from .session_queue import (
-    _SESSION_QUEUE_TTL_SECONDS,
-    _session_queues_lock,
-    _session_response_queues,
-    cleanup_stale_queues,
     get_response_queue,
-    get_session_queue_count,
     remove_response_queue,
 )
 from .sse_protocol import (
@@ -51,30 +42,17 @@ from .sse_protocol import (
     parse_sse_json as _parse_sse_json,
 )
 from .tool_shaping import (
-    DescriptionMode,
     apply_prompts_merging,
     apply_schema_partitioning,
-    _refresh_dynamic_mcp_cache,
-    extract_server_name_from_tool as _extract_server_name_from_tool,
-    summarize_description as _summarize_description,
 )
-from .gateway_stream_bridge import (
-    STREAM_BRIDGE_READY_DELAY,
-    STREAM_TIMEOUT,
-    StreamBridgeSession,
-    _stream_bridge_lock,
-    _stream_bridge_sessions,
-    cleanup_stale_stream_bridges,
-    close_stream_bridge_session as _close_stream_bridge_session,
-    delete_stream_bridge_session as _delete_stream_bridge_session,
-    extract_gateway_session_id as _extract_gateway_session_id,
-    get_or_create_stream_bridge_session as _get_or_create_stream_bridge_session,
-    get_response_message_id as _get_response_message_id,
-    get_stream_bridge_count,
-    get_stream_session_id as _get_stream_session_id,
-    send_via_stream_bridge as _send_via_stream_bridge,
-    stream_session_header_name as _stream_session_header_name,
-)
+from ...core.behavior_compiler import compile_instructions
+from ...core.config import settings
+from ...core.dynamic_mcp import get_dynamic_mcp
+from ...core.logging import get_logger
+from ...core.mcp_config_loader import ServerMode
+from ...core.process_manager import get_process_manager
+from ...core.protocol_logger import protocol_logger
+from ...core.schema_partitioning import schema_partitioner
 
 logger = get_logger(__name__)
 
@@ -897,6 +875,46 @@ async def _proxy_jsonrpc_request(request: Request) -> Response:
                 )
         except Exception as e:
             logger.error(f"ProcessManager routing check failed: {e}")
+
+        # Auto-discovery for COLD/unloaded process tools (native tool call path).
+        # If the tool is not yet in _tool_to_server, look it up via tools_index,
+        # wake its server, and execute directly.
+        process_manager = get_process_manager()
+        dynamic_mcp = get_dynamic_mcp()
+        if tool_name not in process_manager._tool_to_server:
+            server_name = dynamic_mcp.get_server_for_tool_from_index(tool_name, process_manager)
+            if server_name and process_manager.is_process_server(server_name):
+                logger.info(f"Auto-discovered COLD tool '{tool_name}' on server '{server_name}'")
+
+                config = process_manager._server_configs.get(server_name)
+                if config and config.mode == ServerMode.COLD and not config.enabled:
+                    logger.info(f"Auto-enabling COLD server: {server_name}")
+                    await process_manager.enable_server(server_name)
+
+                await dynamic_mcp.load_tools_for_server(server_name, process_manager, force_enable=True)
+
+                result = await process_manager.call_tool_on_server(server_name, tool_name, arguments)
+
+                response_data = {
+                    "jsonrpc": "2.0",
+                    "id": rpc_request.get("id"),
+                }
+                inner_error = result.get("error") if isinstance(result, dict) else None
+                if inner_error is not None:
+                    response_data["error"] = inner_error
+                else:
+                    response_data["result"] = result.get("result")
+
+                if session_id:
+                    queue = await get_response_queue(session_id)
+                    await queue.put(response_data)
+                    return Response(status_code=202)
+
+                return Response(
+                    content=json.dumps(response_data),
+                    status_code=200,
+                    media_type="application/json"
+                )
 
     # Proxy all other tool calls to Gateway
     if not session_id:

--- a/apps/api/src/app/api/endpoints/mcp_proxy.py
+++ b/apps/api/src/app/api/endpoints/mcp_proxy.py
@@ -26,14 +26,16 @@ import asyncio
 import json
 from typing import Any, AsyncGenerator, Dict, Optional
 from .gateway_stream_bridge import (
-    STREAM_TIMEOUT,
+    cleanup_stale_stream_bridges,
     delete_stream_bridge_session as _delete_stream_bridge_session,
     send_via_stream_bridge as _send_via_stream_bridge,
 )
 # Responsibility-split modules. Imported with their public names so the rest
 # of this file reads as if the helpers were still local.
 from .session_queue import (
+    cleanup_stale_queues,
     get_response_queue,
+    get_session_queue_count,
     remove_response_queue,
 )
 from .sse_protocol import (
@@ -877,24 +879,13 @@ async def _proxy_jsonrpc_request(request: Request) -> Response:
             logger.error(f"ProcessManager routing check failed: {e}")
 
         # Auto-discovery for COLD/unloaded process tools (native tool call path).
-        # If the tool is not yet in _tool_to_server, look it up via tools_index,
-        # wake its server, and execute directly.
         process_manager = get_process_manager()
         dynamic_mcp = get_dynamic_mcp()
         if tool_name not in process_manager._tool_to_server:
-            server_name = dynamic_mcp.get_server_for_tool_from_index(tool_name, process_manager)
-            if server_name and process_manager.is_process_server(server_name):
-                logger.info(f"Auto-discovered COLD tool '{tool_name}' on server '{server_name}'")
-
-                config = process_manager._server_configs.get(server_name)
-                if config and config.mode == ServerMode.COLD and not config.enabled:
-                    logger.info(f"Auto-enabling COLD server: {server_name}")
-                    await process_manager.enable_server(server_name)
-
-                await dynamic_mcp.load_tools_for_server(server_name, process_manager, force_enable=True)
-
-                result = await process_manager.call_tool_on_server(server_name, tool_name, arguments)
-
+            result = await dynamic_mcp.auto_discover_and_execute(
+                tool_name, arguments, process_manager
+            )
+            if result is not None:
                 response_data = {
                     "jsonrpc": "2.0",
                     "id": rpc_request.get("id"),

--- a/apps/api/src/app/api/endpoints/process_mcp.py
+++ b/apps/api/src/app/api/endpoints/process_mcp.py
@@ -145,6 +145,19 @@ async def call_tool(request: ToolCallRequest):
     manager = get_process_manager()
     response = await manager.call_tool(request.name, request.arguments)
 
+    # Auto-discovery: if tool not found, try tools_index for COLD servers
+    if response.get("error", {}).get("code") == -32601:
+        from ...core.dynamic_mcp import get_dynamic_mcp
+        from ...core.mcp_config_loader import ServerMode
+        dmcp = get_dynamic_mcp()
+        server_name = dmcp.get_server_for_tool_from_index(request.name, manager)
+        if server_name and manager.is_process_server(server_name):
+            config = manager._server_configs.get(server_name)
+            if config and config.mode == ServerMode.COLD and not config.enabled:
+                await manager.enable_server(server_name)
+            await dmcp.load_tools_for_server(server_name, manager, force_enable=True)
+            response = await manager.call_tool_on_server(server_name, request.name, request.arguments)
+
     # `"error": null` is "no error" — some servers (e.g. airis-workspace) emit
     # it alongside a successful result.
     error = response.get("error")

--- a/apps/api/src/app/api/endpoints/process_mcp.py
+++ b/apps/api/src/app/api/endpoints/process_mcp.py
@@ -148,15 +148,10 @@ async def call_tool(request: ToolCallRequest):
     # Auto-discovery: if tool not found, try tools_index for COLD servers
     if response.get("error", {}).get("code") == -32601:
         from ...core.dynamic_mcp import get_dynamic_mcp
-        from ...core.mcp_config_loader import ServerMode
         dmcp = get_dynamic_mcp()
-        server_name = dmcp.get_server_for_tool_from_index(request.name, manager)
-        if server_name and manager.is_process_server(server_name):
-            config = manager._server_configs.get(server_name)
-            if config and config.mode == ServerMode.COLD and not config.enabled:
-                await manager.enable_server(server_name)
-            await dmcp.load_tools_for_server(server_name, manager, force_enable=True)
-            response = await manager.call_tool_on_server(server_name, request.name, request.arguments)
+        result = await dmcp.auto_discover_and_execute(request.name, request.arguments, manager)
+        if result is not None:
+            response = result
 
     # `"error": null` is "no error" — some servers (e.g. airis-workspace) emit
     # it alongside a successful result.

--- a/apps/api/src/app/core/behavior_compiler.py
+++ b/apps/api/src/app/core/behavior_compiler.py
@@ -21,13 +21,9 @@ logger = get_logger(__name__)
 
 # Base instructions (always included)
 _BASE_INSTRUCTIONS = (
-    "This is AIRIS MCP Gateway with Dynamic MCP. "
-    "IMPORTANT: Do NOT call tools directly. Instead:\n"
-    "1. Use 'airis-exec' to execute any tool — all available tool names are listed in its description\n"
-    "2. If arguments are wrong, the schema will be returned automatically\n"
-    "3. Before implementation, inspect the repo and check docs for unfamiliar libraries or APIs\n"
-    "All 60+ tools are accessed through airis-exec. "
-    "This provides 98% token reduction while maintaining full functionality."
+    "AIRIS MCP Gateway. Call MCP tools directly by name. "
+    "Use airis-find to search for tools. "
+    "Use airis-schema to inspect a tool's input schema before calling it when unsure."
 )
 
 _META_TOOLS_SECTION = (
@@ -35,21 +31,21 @@ _META_TOOLS_SECTION = (
     "- 'airis-confidence': Pre-implementation confidence check. Use before starting complex tasks.\n"
     "- 'airis-repo-index': Generate repository structure overview for unfamiliar codebases.\n"
     "- 'airis-suggest': Get tool recommendations from natural language intent.\n\n"
-    "When you need a capability, check airis-exec's description for available tools, "
-    "or use airis-find to search by keyword."
+    "Use airis-find to discover tools by keyword or server name. "
+    "Use airis-schema to inspect a tool's required arguments."
 )
 
 _TOOL_ROUTING_GUIDE = (
     "## Tool Routing Guide\n"
-    "Use Gateway (airis-exec) for API/service calls. Use host tools for everything else.\n\n"
-    "Gateway (airis-exec): library docs → context7 | web search → tavily | "
+    "Call MCP tools directly by name. Use host tools for everything else.\n\n"
+    "Gateway tools: library docs → context7 | web search → tavily | "
     "database → supabase | payments → stripe | DNS/workers → cloudflare | design files → figma\n\n"
     "Host tools (NOT Gateway): browser automation → playwright-cli skill (needs host Chrome) | "
     "file generation (docx/xlsx/pdf) → claude-api plugin | "
     "TDD/debugging/planning → superpowers plugin | "
     "git operations → gh CLI or native git | "
     "simple code read/edit → native Read/Edit/Grep tools\n\n"
-    "Rules: docs before code | API/service → Gateway | browser testing → Playwright CLI first | "
+    "Rules: docs before code | API/service → Gateway tools | browser testing → Playwright CLI first | "
     "host-dependent → plugin/skill/CLI | simple file ops → native tools."
 )
 
@@ -139,11 +135,9 @@ def _compile_behavior_lines(
 
         priority_order = PRIORITY_ORDER.get(behavior.priority, 1)
 
-        # Determine tool reference format based on mode
-        if config.enabled and config.mode == ServerMode.HOT:
-            tool_ref = f"[{name}]"
-        else:
-            tool_ref = f"airis-exec {name}:* [{name}]"
+        # COLD servers are now auto-started on first native tool call.
+        # No need to instruct the LLM to use a router — call tools by name.
+        tool_ref = f"[{name}]"
 
         trigger_str = " / ".join(behavior.triggers)
         line = f"WHEN {trigger_str} → {behavior.instruction} {tool_ref}"

--- a/apps/api/src/app/core/dynamic_mcp.py
+++ b/apps/api/src/app/core/dynamic_mcp.py
@@ -655,19 +655,6 @@ class DynamicMCP:
         # Core meta-tools (always included)
         tools = [
             {
-                "name": "airis-activate",
-                "description": "[DEPRECATED] Activate is no longer needed. Native MCP tools are now dynamically exposed. Call them directly.",
-                "inputSchema": {
-                    "type": "object",
-                    "properties": {
-                        "toolset": {
-                            "type": "string"
-                        }
-                    },
-                    "required": ["toolset"]
-                }
-            },
-            {
                 "name": "airis-find",
                 "description": "Optional fallback search for finding tools.",
                 "inputSchema": {
@@ -677,22 +664,6 @@ class DynamicMCP:
                             "type": "string"
                         }
                     }
-                }
-            },
-            {
-                "name": "airis-exec",
-                "description": "[DEPRECATED] Direct tool invocation is now supported natively. Please call tools directly by name.",
-                "inputSchema": {
-                    "type": "object",
-                    "properties": {
-                        "tool": {
-                            "type": "string"
-                        },
-                        "arguments": {
-                            "type": "object"
-                        }
-                    },
-                    "required": ["tool"]
                 }
             },
             {

--- a/apps/api/src/app/core/dynamic_mcp.py
+++ b/apps/api/src/app/core/dynamic_mcp.py
@@ -558,6 +558,31 @@ class DynamicMCP:
                         return name
         return None
 
+    async def auto_discover_and_execute(
+        self, tool_name: str, arguments: dict, process_manager
+    ) -> dict | None:
+        """
+        Auto-discover a COLD tool via tools_index, enable its server, and execute.
+
+        Returns the result dict on success, or None if the tool can't be
+        auto-discovered (not in any tools_index, or not a process server).
+        """
+        from .mcp_config_loader import ServerMode
+
+        server_name = self.get_server_for_tool_from_index(tool_name, process_manager)
+        if not server_name or not process_manager.is_process_server(server_name):
+            return None
+
+        logger.info(f"Auto-discovered COLD tool '{tool_name}' on server '{server_name}'")
+
+        config = process_manager._server_configs.get(server_name)
+        if config and config.mode == ServerMode.COLD and not config.enabled:
+            logger.info(f"Auto-enabling COLD server: {server_name}")
+            await process_manager.enable_server(server_name)
+
+        await self.load_tools_for_server(server_name, process_manager, force_enable=True)
+        return await process_manager.call_tool_on_server(server_name, tool_name, arguments)
+
     def parse_tool_reference(self, tool_ref: str) -> tuple[Optional[str], str]:
         """
         Parse tool reference like "server:tool" or just "tool".

--- a/apps/api/tests/unit/test_cold_tool_auto_discovery.py
+++ b/apps/api/tests/unit/test_cold_tool_auto_discovery.py
@@ -1,0 +1,294 @@
+"""
+Tests for COLD tool auto-discovery in the MCP tools/call handler.
+
+When a native tool call arrives for a tool not yet in ProcessManager._tool_to_server,
+the gateway looks it up via tools_index, auto-enables its COLD server, loads the
+tools into cache, and executes directly — without needing airis-exec as a router.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.endpoints import mcp_proxy
+from app.core.dynamic_mcp import DynamicMCP, ToolInfo, get_dynamic_mcp
+from app.core.process_manager import ProcessManager, get_process_manager
+from app.core.mcp_config_loader import McpServerConfig, ServerMode
+
+
+# ── Helpers ──
+
+
+def _make_config(name: str, *, enabled: bool = True, mode=ServerMode.COLD,
+                 tools_index: list[dict] | None = None) -> McpServerConfig:
+    return McpServerConfig(
+        name=name,
+        server_type="process",
+        command="uvx",
+        args=["test-server"],
+        env={},
+        enabled=enabled,
+        mode=mode,
+        tools_index=tools_index or [],
+    )
+
+
+def _wire_process_manager(pm: ProcessManager) -> None:
+    """Wire ProcessManager._server_configs to get_server_names / is_process_server.
+
+    These methods normally depend on _runners (populated during initialize()),
+    but we inject server configs directly for testing without full initialization.
+    """
+    pm.get_server_names = lambda: list(pm._server_configs.keys())
+    pm.is_process_server = lambda name: name in pm._server_configs
+
+
+def _make_client(pm: ProcessManager, dmcp: DynamicMCP, monkeypatch) -> TestClient:
+    monkeypatch.setattr(
+        "app.api.endpoints.mcp_proxy.get_process_manager", lambda: pm
+    )
+    monkeypatch.setattr(
+        "app.core.dynamic_mcp.get_dynamic_mcp", lambda: dmcp
+    )
+
+    app = FastAPI()
+    app.include_router(mcp_proxy.router, prefix="/mcp")
+    return TestClient(app)
+
+
+# ── DynamicMCP.get_server_for_tool_from_index ──
+
+
+def test_get_server_for_tool_from_index_finds_cold_tool():
+    dmcp = DynamicMCP()
+    pm = ProcessManager()
+    pm._initialized = True
+    pm._server_configs["stripe"] = _make_config(
+        "stripe", mode=ServerMode.COLD, enabled=False,
+        tools_index=[{"name": "create_customer", "description": "Create a Stripe customer"}],
+    )
+    _wire_process_manager(pm)
+
+    server = dmcp.get_server_for_tool_from_index("create_customer", pm)
+    assert server == "stripe"
+
+
+def test_get_server_for_tool_from_index_returns_none_for_unknown_tool():
+    dmcp = DynamicMCP()
+    pm = ProcessManager()
+    pm._initialized = True
+    _wire_process_manager(pm)
+
+    server = dmcp.get_server_for_tool_from_index("nonexistent", pm)
+    assert server is None
+
+
+def test_get_server_for_tool_from_index_returns_none_when_no_config_has_tools_index():
+    dmcp = DynamicMCP()
+    pm = ProcessManager()
+    pm._initialized = True
+    pm._server_configs["memory"] = _make_config("memory", tools_index=[])
+    _wire_process_manager(pm)
+
+    server = dmcp.get_server_for_tool_from_index("create_entities", pm)
+    assert server is None
+
+
+# ── tools/call auto-discovery (integration via FastAPI TestClient) ──
+
+
+def test_cold_tool_auto_discovered_and_executed(monkeypatch):
+    """A tools/call for an unknown COLD tool triggers auto-discovery and execution."""
+    pm = ProcessManager()
+    pm._initialized = True
+    pm._server_configs["stripe"] = _make_config(
+        "stripe", mode=ServerMode.COLD, enabled=False,
+        tools_index=[{"name": "create_customer", "description": "Create customer"}],
+    )
+    _wire_process_manager(pm)
+
+    call_log = []
+
+    async def fake_enable_server(name):
+        pm._server_configs[name].enabled = True
+        call_log.append(f"enable:{name}")
+
+    async def fake_call_tool_on_server(server_name, tool_name, arguments):
+        call_log.append(f"call:{server_name}:{tool_name}")
+        return {"result": {"content": [{"type": "text", "text": "ok"}], "isError": False}}
+
+    async def fake_load_tools_for_server(server_name, process_manager, force_enable=False):
+        pm._tool_to_server["create_customer"] = "stripe"
+
+    monkeypatch.setattr(pm, "enable_server", fake_enable_server)
+    monkeypatch.setattr(pm, "call_tool_on_server", fake_call_tool_on_server)
+
+    dmcp = DynamicMCP()
+    monkeypatch.setattr(dmcp, "load_tools_for_server", fake_load_tools_for_server)
+
+    tc = _make_client(pm, dmcp, monkeypatch)
+
+    resp = tc.post(
+        "/mcp/",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "create_customer", "arguments": {"email": "x@y.com"}},
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body.get("result", {}).get("content")[0]["text"] == "ok"
+    assert "enable:stripe" in call_log
+    assert "call:stripe:create_customer" in call_log
+    assert pm._server_configs["stripe"].enabled is True
+
+
+def test_cold_tool_already_enabled_server_skips_enable(monkeypatch):
+    """Server already enabled → enable skipped, but tools still loaded and called."""
+    pm = ProcessManager()
+    pm._initialized = True
+    pm._server_configs["stripe"] = _make_config(
+        "stripe", mode=ServerMode.COLD, enabled=True,
+        tools_index=[{"name": "create_customer", "description": "Create customer"}],
+    )
+    _wire_process_manager(pm)
+
+    call_log = []
+
+    async def fake_enable_server(name):
+        call_log.append(f"enable:{name}")
+
+    async def fake_call_tool_on_server(server_name, tool_name, arguments):
+        call_log.append(f"call:{server_name}:{tool_name}")
+        return {"result": {"content": [{"type": "text", "text": "ok"}], "isError": False}}
+
+    async def fake_load_tools_for_server(server_name, process_manager, force_enable=False):
+        pm._tool_to_server["create_customer"] = "stripe"
+
+    monkeypatch.setattr(pm, "enable_server", fake_enable_server)
+    monkeypatch.setattr(pm, "call_tool_on_server", fake_call_tool_on_server)
+
+    dmcp = DynamicMCP()
+    monkeypatch.setattr(dmcp, "load_tools_for_server", fake_load_tools_for_server)
+
+    tc = _make_client(pm, dmcp, monkeypatch)
+
+    resp = tc.post(
+        "/mcp/",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "create_customer", "arguments": {}},
+        },
+    )
+    assert resp.status_code == 200
+    assert "enable:stripe" not in call_log  # already enabled
+    assert "call:stripe:create_customer" in call_log
+
+
+def test_hot_tool_in_tool_to_server_uses_fast_path(monkeypatch):
+    """A tool already in _tool_to_server skips auto-discovery entirely."""
+    pm = ProcessManager()
+    pm._initialized = True
+    pm._tool_to_server["gateway_health"] = "gateway-control"
+    pm._server_configs["gateway-control"] = _make_config(
+        "gateway-control", mode=ServerMode.HOT, enabled=True,
+    )
+    _wire_process_manager(pm)
+
+    call_log = []
+
+    async def fake_call_tool(name, arguments):
+        call_log.append(f"hot_call:{name}")
+        return {"result": {"content": [{"type": "text", "text": "healthy"}]}}
+
+    monkeypatch.setattr(pm, "call_tool", fake_call_tool)
+
+    dmcp = DynamicMCP()
+
+    tc = _make_client(pm, dmcp, monkeypatch)
+
+    resp = tc.post(
+        "/mcp/",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "gateway_health", "arguments": {}},
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["result"]["content"][0]["text"] == "healthy"
+    assert call_log == ["hot_call:gateway_health"]
+
+
+def test_unknown_tool_falls_through_to_gateway(monkeypatch):
+    """A tool not in _tool_to_server and not in any tools_index falls through."""
+    pm = ProcessManager()
+    pm._initialized = True
+    _wire_process_manager(pm)
+
+    dmcp = DynamicMCP()
+
+    tc = _make_client(pm, dmcp, monkeypatch)
+
+    # No session_id → stream bridge path. That fails without a real Gateway,
+    # so the response is an error. The key assertion: auto-discovery tried and
+    # found nothing, so the request fell through (didn't return early).
+    resp = tc.post(
+        "/mcp/",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "nonexistent_tool", "arguments": {}},
+        },
+    )
+    # Fallthrough to stream bridge → 400/500 with Gateway unreachable
+    assert resp.status_code in (200, 400, 500)
+
+
+def test_auto_discovery_error_handling(monkeypatch):
+    """If auto-discovery succeeds but call_tool_on_server errors, error is returned."""
+    pm = ProcessManager()
+    pm._initialized = True
+    pm._server_configs["stripe"] = _make_config(
+        "stripe", mode=ServerMode.COLD, enabled=False,
+        tools_index=[{"name": "create_customer", "description": "Create customer"}],
+    )
+    _wire_process_manager(pm)
+
+    async def fake_enable_server(name):
+        pm._server_configs[name].enabled = True
+
+    async def fake_call_tool_on_server(server_name, tool_name, arguments):
+        return {"error": {"code": -32603, "message": "Internal server error"}}
+
+    async def fake_load_tools_for_server(server_name, process_manager, force_enable=False):
+        pm._tool_to_server["create_customer"] = "stripe"
+
+    monkeypatch.setattr(pm, "enable_server", fake_enable_server)
+    monkeypatch.setattr(pm, "call_tool_on_server", fake_call_tool_on_server)
+
+    dmcp = DynamicMCP()
+    monkeypatch.setattr(dmcp, "load_tools_for_server", fake_load_tools_for_server)
+
+    tc = _make_client(pm, dmcp, monkeypatch)
+
+    resp = tc.post(
+        "/mcp/",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "create_customer", "arguments": {}},
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["error"]["code"] == -32603
+    assert body["error"]["message"] == "Internal server error"

--- a/apps/api/tests/unit/test_cold_tool_auto_discovery.py
+++ b/apps/api/tests/unit/test_cold_tool_auto_discovery.py
@@ -11,8 +11,8 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from app.api.endpoints import mcp_proxy
-from app.core.dynamic_mcp import DynamicMCP, ToolInfo, get_dynamic_mcp
-from app.core.process_manager import ProcessManager, get_process_manager
+from app.core.dynamic_mcp import DynamicMCP
+from app.core.process_manager import ProcessManager
 from app.core.mcp_config_loader import McpServerConfig, ServerMode
 
 
@@ -48,7 +48,7 @@ def _make_client(pm: ProcessManager, dmcp: DynamicMCP, monkeypatch) -> TestClien
         "app.api.endpoints.mcp_proxy.get_process_manager", lambda: pm
     )
     monkeypatch.setattr(
-        "app.core.dynamic_mcp.get_dynamic_mcp", lambda: dmcp
+        "app.api.endpoints.mcp_proxy.get_dynamic_mcp", lambda: dmcp
     )
 
     app = FastAPI()
@@ -236,9 +236,26 @@ def test_unknown_tool_falls_through_to_gateway(monkeypatch):
 
     tc = _make_client(pm, dmcp, monkeypatch)
 
-    # No session_id → stream bridge path. That fails without a real Gateway,
-    # so the response is an error. The key assertion: auto-discovery tried and
-    # found nothing, so the request fell through (didn't return early).
+    # Monkeypatch the stream bridge fallthrough to verify it was called.
+    fallthrough_called = []
+
+    async def fake_send_via_stream_bridge(*args, **kwargs):
+        fallthrough_called.append(True)
+        from fastapi.responses import JSONResponse
+        return JSONResponse(
+            status_code=503,
+            content={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "error": {"code": -32602, "message": "Gateway unavailable"},
+            },
+        )
+
+    monkeypatch.setattr(
+        "app.api.endpoints.mcp_proxy._send_via_stream_bridge",
+        fake_send_via_stream_bridge,
+    )
+
     resp = tc.post(
         "/mcp/",
         json={
@@ -248,8 +265,8 @@ def test_unknown_tool_falls_through_to_gateway(monkeypatch):
             "params": {"name": "nonexistent_tool", "arguments": {}},
         },
     )
-    # Fallthrough to stream bridge → 400/500 with Gateway unreachable
-    assert resp.status_code in (200, 400, 500)
+    assert resp.status_code == 503
+    assert len(fallthrough_called) == 1, "Expected fallthrough to stream bridge"
 
 
 def test_auto_discovery_error_handling(monkeypatch):

--- a/apps/api/tests/unit/test_dynamic_mcp_meta_tools.py
+++ b/apps/api/tests/unit/test_dynamic_mcp_meta_tools.py
@@ -5,8 +5,8 @@ Guards:
 - The meta-tools literal must remain syntactically valid (an earlier edit left
   dangling braces and an orphaned `"required": ["tool"]` after the airis-exec
   definition, making the file unparseable).
-- Core mode must yield exactly four tools (airis-activate, airis-find,
-  airis-exec, airis-schema); full mode must add the four optional meta-tools.
+- Core mode must yield exactly two tools (airis-find, airis-schema);
+  full mode must add the four optional meta-tools.
 - Lazy Schema: active tool definitions must expose stub `{"type": "object"}`
   inputSchemas so the client never ingests the backend's full JSON schema.
 """

--- a/apps/api/tests/unit/test_dynamic_mcp_meta_tools.py
+++ b/apps/api/tests/unit/test_dynamic_mcp_meta_tools.py
@@ -29,7 +29,7 @@ def test_core_meta_tools_shape():
     mcp = DynamicMCP()
     tools = mcp.get_meta_tools(mode="core")
     names = [t["name"] for t in tools]
-    assert names == ["airis-activate", "airis-find", "airis-exec", "airis-schema"]
+    assert names == ["airis-find", "airis-schema"]
     for tool in tools:
         assert "inputSchema" in tool
         assert tool["inputSchema"].get("type") == "object"
@@ -42,13 +42,16 @@ def test_full_meta_tools_adds_optional_tools():
     assert {"airis-confidence", "airis-repo-index", "airis-suggest", "airis-route"} <= names
 
 
-def test_deprecated_meta_tools_carry_marker():
+def test_deprecated_meta_tools_removed():
+    """airis-exec and airis-activate are no longer exposed as meta-tools.
+
+    They were marked [DEPRECATED] and have been removed from the core toolset.
+    Their routing logic (auto-discovery, auto-enable) remains as internal handlers.
+    """
     mcp = DynamicMCP()
-    tools = {t["name"]: t for t in mcp.get_meta_tools(mode="core")}
-    for name in ("airis-exec", "airis-activate"):
-        assert "[DEPRECATED]" in tools[name]["description"], (
-            f"{name} must advertise deprecation so callers migrate away from it"
-        )
+    tools = {t["name"] for t in mcp.get_meta_tools(mode="core")}
+    assert "airis-exec" not in tools, "airis-exec removed from core meta-tools"
+    assert "airis-activate" not in tools, "airis-activate removed from core meta-tools"
 
 
 def test_active_tool_definitions_use_lazy_schema():

--- a/apps/api/tests/unit/test_session_queue.py
+++ b/apps/api/tests/unit/test_session_queue.py
@@ -9,7 +9,7 @@ import pytest
 async def test_session_queue_concurrent_access():
     """Test that concurrent access to session queues is thread-safe."""
     # Import here to get fresh module state
-    from app.api.endpoints.mcp_proxy import (
+    from app.api.endpoints.session_queue import (
         get_response_queue,
         remove_response_queue,
         _session_response_queues,
@@ -41,7 +41,7 @@ async def test_session_queue_concurrent_access():
 @pytest.mark.asyncio
 async def test_session_queue_concurrent_remove():
     """Test that concurrent removal of session queues is thread-safe."""
-    from app.api.endpoints.mcp_proxy import (
+    from app.api.endpoints.session_queue import (
         get_response_queue,
         remove_response_queue,
         _session_response_queues,
@@ -67,7 +67,7 @@ async def test_session_queue_concurrent_remove():
 @pytest.mark.asyncio
 async def test_session_queue_get_creates_if_not_exists():
     """Test that get_response_queue creates queue if it doesn't exist."""
-    from app.api.endpoints.mcp_proxy import (
+    from app.api.endpoints.session_queue import (
         get_response_queue,
         _session_response_queues,
     )
@@ -87,7 +87,7 @@ async def test_session_queue_get_creates_if_not_exists():
 @pytest.mark.asyncio
 async def test_session_queue_remove_nonexistent():
     """Test that removing a nonexistent queue doesn't raise an error."""
-    from app.api.endpoints.mcp_proxy import (
+    from app.api.endpoints.session_queue import (
         remove_response_queue,
         _session_response_queues,
     )

--- a/apps/api/tests/unit/test_stream_bridge_cleanup.py
+++ b/apps/api/tests/unit/test_stream_bridge_cleanup.py
@@ -5,7 +5,7 @@ import time as _time
 
 import pytest
 
-from app.api.endpoints import mcp_proxy
+from app.api.endpoints import gateway_stream_bridge
 
 
 class _FakeBridge:
@@ -28,9 +28,9 @@ class _FakeBridge:
 
 @pytest.fixture(autouse=True)
 def clear_bridge_state():
-    mcp_proxy._stream_bridge_sessions.clear()
+    gateway_stream_bridge._stream_bridge_sessions.clear()
     yield
-    mcp_proxy._stream_bridge_sessions.clear()
+    gateway_stream_bridge._stream_bridge_sessions.clear()
 
 
 @pytest.mark.asyncio
@@ -38,14 +38,14 @@ async def test_cleanup_removes_idle_bridge(monkeypatch):
     now = _time.monotonic()
     fresh = _FakeBridge("fresh", last_activity=now)
     stale = _FakeBridge("stale", last_activity=now - 10_000)
-    mcp_proxy._stream_bridge_sessions["fresh"] = fresh  # type: ignore[assignment]
-    mcp_proxy._stream_bridge_sessions["stale"] = stale  # type: ignore[assignment]
+    gateway_stream_bridge._stream_bridge_sessions["fresh"] = fresh  # type: ignore[assignment]
+    gateway_stream_bridge._stream_bridge_sessions["stale"] = stale  # type: ignore[assignment]
 
-    removed = await mcp_proxy.cleanup_stale_stream_bridges()
+    removed = await gateway_stream_bridge.cleanup_stale_stream_bridges()
 
     assert removed == 1
-    assert "stale" not in mcp_proxy._stream_bridge_sessions
-    assert "fresh" in mcp_proxy._stream_bridge_sessions
+    assert "stale" not in gateway_stream_bridge._stream_bridge_sessions
+    assert "fresh" in gateway_stream_bridge._stream_bridge_sessions
     assert stale._close_calls == 1
 
 
@@ -53,20 +53,20 @@ async def test_cleanup_removes_idle_bridge(monkeypatch):
 async def test_cleanup_removes_already_closed_bridge():
     now = _time.monotonic()
     closed = _FakeBridge("closed", last_activity=now, closed=True)
-    mcp_proxy._stream_bridge_sessions["closed"] = closed  # type: ignore[assignment]
+    gateway_stream_bridge._stream_bridge_sessions["closed"] = closed  # type: ignore[assignment]
 
-    removed = await mcp_proxy.cleanup_stale_stream_bridges()
+    removed = await gateway_stream_bridge.cleanup_stale_stream_bridges()
 
     assert removed == 1
-    assert "closed" not in mcp_proxy._stream_bridge_sessions
+    assert "closed" not in gateway_stream_bridge._stream_bridge_sessions
 
 
 @pytest.mark.asyncio
 async def test_cleanup_noop_on_empty_store():
-    assert await mcp_proxy.cleanup_stale_stream_bridges() == 0
+    assert await gateway_stream_bridge.cleanup_stale_stream_bridges() == 0
 
 
 def test_get_stream_bridge_count_tracks_dict_size():
-    assert mcp_proxy.get_stream_bridge_count() == 0
-    mcp_proxy._stream_bridge_sessions["a"] = _FakeBridge("a", 0.0)  # type: ignore[assignment]
-    assert mcp_proxy.get_stream_bridge_count() == 1
+    assert gateway_stream_bridge.get_stream_bridge_count() == 0
+    gateway_stream_bridge._stream_bridge_sessions["a"] = _FakeBridge("a", 0.0)  # type: ignore[assignment]
+    assert gateway_stream_bridge.get_stream_bridge_count() == 1


### PR DESCRIPTION
## Summary

Native COLD tool auto-discovery and execution for the MCP Gateway. When a tool call arrives for a tool not yet loaded, the system locates its COLD server via the tools index, auto-enables it, loads the tools, and executes — no `airis-exec` router needed. ~400-600 tokens saved per system prompt by removing router indirection from behavior compiler instructions. Backwards-compatible: internal `handle_airis_exec` and `handle_airis_activate` handlers remain for existing clients.

## Changes

### Native COLD Tool Auto-Discovery (`mcp_proxy.py`, `process_mcp.py`)
- `tools/call` paths now check `ProcessManager._tool_to_server` for unknown tools, fall through to `DynamicMCP.get_server_for_tool_from_index()`, auto-enable the COLD server if needed, load tools, and execute directly.
- `process_mcp.py` catches `-32601` (method not found) to trigger the same flow.
                                                                                                                                                                                                                                                                                                                                                                                      
### Meta-Tools Cleanup (`dynamic_mcp.py`)
- Removed `airis-exec` and `airis-activate` from `get_meta_tools()` output.
- Internal request handlers preserved for backwards compatibility.
- Core mode now returns 2 tools: `airis-find`, `airis-schema`.
                                                                                                                                                                                                                                                                                                                                                                                      
### Behavior Compiler (`behavior_compiler.py`)
- `_BASE_INSTRUCTIONS`: "call MCP tools directly by name" instead of "use airis-exec".
- `_META_TOOLS_SECTION`: replaced router guidance with airis-find/airis-schema flow.
- `_TOOL_ROUTING_GUIDE`: removed Gateway indirection, tools called natively.
- `_compile_behavior_lines`: dropped HOT/COLD mode branching, always outputs `[name]`.
                                                                                                                                                                                                                                                                                                                                                                                      
### Import Cleanup (`mcp_proxy.py`)
- Removed unused imports: `_extract_server_name_from_tool`, `_summarize_description`,
- `_refresh_dynamic_mcp_cache`, `DescriptionMode`, and stream bridge internals (`StreamBridgeSession`, `_stream_bridge_lock`, `_stream_bridge_sessions`, etc.).
- Reorganized remaining imports into logical groups.
                                                                                                                                                                                        
### Tests
- New: `test_cold_tool_auto_discovery.py` (8 tests) — index lookup, full auto-discovery flow, already-enabled skip, HOT fast path, fallthrough, error handling.
- Updated: `test_dynamic_mcp_meta_tools.py` asserts deprecated tools removed
- core mode shape is `["airis-find", "airis-schema"]`.