### PR TITLE
chore: gitignore compose.yaml (generated by airis gen)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ __pycache__/
 auto-imports.d.ts
 .modules.yaml
 .pnpm-workspace-state-v1.json
+compose.yaml
 
 # Auto-generated backups
 backups/


### PR DESCRIPTION
## Summary

- `compose.yaml` を `.gitignore` に追加

`compose.yaml` は `airis gen` が生成するビルド環境用の compose ファイル（dev workspace containers）。トラックしてはいけない理由：

1. Docker Compose V2 は `compose.yaml` を `docker-compose.yml` より優先するため、`docker compose up` がランタイムサービスではなく dev コンテナを対象にしてしまう
2. 生成物なのでコミットしても意味がなく、マシンごとに異なる

## 背景

airis-workspace PR #229 で `compose.yaml` 生成のバグを修正（`version: "3.8"` 除去、Python アプリへの正しいイメージ割り当て、`[apps.X]` 形式のサポート）。

## Test plan

- [ ] `git status` で `compose.yaml` が表示されないことを確認
- [ ] `docker compose up -d` が `docker-compose.yml` を使うことを確認（ファイル指定なしでも OK）

🤖 Generated with [Claude Code](https://claude.ai/claude-code)