### PR TITLE
fix: pin docker-compose images and add dependency audit to CI (#77 #94)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,12 @@ jobs:
           pip install bandit
           bandit -r apps/api/src -ll -ii
 
+      - name: Audit Python dependencies (pip-audit)
+        run: |
+          pip install pip-audit
+          cd apps/api
+          pip-audit --strict
+
   # TypeScript build and test (only when TS files change)
   build-typescript:
     needs: changes
@@ -115,6 +121,11 @@ jobs:
         run: |
           cd apps/${{ matrix.package }}
           npm run build
+
+      - name: Audit npm dependencies
+        run: |
+          cd apps/${{ matrix.package }}
+          npm audit --audit-level=high
 
   test-shell:
     needs: changes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
   # Semantic code retrieval and editing capabilities
   serena:
     container_name: airis-serena
-    image: ghcr.io/oraios/serena:latest
+    image: ghcr.io/oraios/serena:v1.2.0
     command:
       - serena
       - start-mcp-server
@@ -52,7 +52,9 @@ services:
   # Manages MCP servers from Docker catalog (time, mindbase via stdio)
   gateway:
     container_name: airis-mcp-gateway-core
-    image: docker/mcp-gateway:latest
+    # Pinned by digest — docker/mcp-gateway does not publish versioned tags (issue #77).
+    # Refresh: docker pull docker/mcp-gateway:latest && docker inspect --format='{{index .RepoDigests 0}}' docker/mcp-gateway:latest
+    image: docker/mcp-gateway@sha256:f79574a3f86603ad65fd5c04f1251a2f2ecda56c1df76ed4418c1c11401c9432
     command:
       - --transport=sse
       - --port=9390


### PR DESCRIPTION
## Summary

- **#77 (image pinning)**: `docker-compose.yml` の `:latest` タグを固定
  - `ghcr.io/oraios/serena:latest` → `ghcr.io/oraios/serena:v1.2.0`（現時点の最新）
  - `docker/mcp-gateway:latest` → `docker/mcp-gateway@sha256:f79574a3...`（root `Dockerfile` と同一 digest）
- **#94 (dependency audit)**: `ci.yml` に脆弱性スキャンを追加
  - `pip-audit --strict`（Python 依存関係）→ `test-python` ジョブに追加
  - `npm audit --audit-level=high`（Node.js 依存関係）→ `build-typescript` ジョブに追加

## Test plan

- [ ] CI が通ること
- [ ] `docker-compose.yml` で `docker compose pull` が pinned タグで動作すること

Closes #77, #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)