### PR TITLE
feat(config): expand airis-workspace MCP tools to full CLI coverage

### DIFF
--- a/mcp-config.json.example
+++ b/mcp-config.json.example
@@ -15,13 +15,29 @@
         {"name": "workspace_doctor", "description": "Diagnose environment drift and suggest fixes (read-only)"},
         {"name": "workspace_verify", "description": "Execute manifest [rule.verify] commands inside the Docker workspace"},
         {"name": "workspace_status", "description": "Show running Docker services (docker compose ps)"},
+        {"name": "workspace_up", "description": "Start all Docker services in the workspace"},
+        {"name": "workspace_down", "description": "Stop all Docker services in the workspace"},
+        {"name": "workspace_restart", "description": "Restart one or all Docker services"},
+        {"name": "workspace_logs", "description": "Fetch Docker service logs (optionally filtered by service name and tail count)"},
+        {"name": "workspace_install", "description": "Install dependencies inside the Docker workspace"},
+        {"name": "workspace_run", "description": "Run a task defined in manifest.toml [commands] or delegate to Docker"},
+        {"name": "workspace_exec", "description": "Execute an arbitrary command inside the Docker workspace container"},
+        {"name": "workspace_test", "description": "Run the test suite inside Docker"},
+        {"name": "workspace_build", "description": "Build one or all projects inside Docker"},
+        {"name": "workspace_lint", "description": "Run linting inside Docker"},
+        {"name": "workspace_typecheck", "description": "Run type checking inside Docker"},
+        {"name": "workspace_clean", "description": "Remove build artifacts (dry-run by default; force=true to delete)"},
+        {"name": "workspace_affected", "description": "List packages affected by changes relative to a base ref"},
         {"name": "manifest_validate", "description": "Validate a proposed manifest.toml string without writing"},
         {"name": "manifest_apply", "description": "Persist a manifest.toml string and optionally run airis gen"},
-        {"name": "migration_execute", "description": "Run a batch of file migration steps proposed by workspace_init"}
+        {"name": "migration_execute", "description": "Run a batch of file migration steps proposed by workspace_init"},
+        {"name": "guards_install", "description": "Install airis command shims (global=true for ~/.airis/bin shims)"},
+        {"name": "guards_status", "description": "Show current airis guard shim status"},
+        {"name": "guards_uninstall", "description": "Remove airis guard shims"}
       ],
       "behavior": {
-        "triggers": ["manifest.toml", "airis workspace", "workspace_init", "/airis:init", "scaffold monorepo", "bootstrap workspace"],
-        "instruction": "Use airis-workspace to bootstrap or maintain manifest.toml-driven monorepos. Call workspace_init to propose a manifest.toml from the current repo, then manifest_apply and workspace_gen to materialize the environment.",
+        "triggers": ["manifest.toml", "airis workspace", "workspace_init", "/airis:init", "scaffold monorepo", "bootstrap workspace", "airis up", "airis down", "airis run", "airis exec", "airis test", "airis build"],
+        "instruction": "Use airis-workspace tools for all Docker-first workspace operations: bootstrap (workspace_init → manifest_apply → workspace_gen), lifecycle (workspace_up/down/restart), development (workspace_run/exec/test/build/lint/typecheck), and maintenance (workspace_clean/doctor/verify).",
         "priority": "high"
       }
     },


### PR DESCRIPTION
## Summary

Syncs `mcp-config.json.example` with airis-workspace v3.18.0 which added 17 new MCP tools.

The airis-workspace MCP server (`airis mcp`) now exposes the full development lifecycle — not just workspace management. Since `airis mcp` uses `current_exe()` self-spawn, a single downloaded binary covers both CLI and MCP use cases.

New tools added to `tools_index`:
- **Lifecycle**: `workspace_up`, `workspace_down`, `workspace_restart`, `workspace_logs`
- **Development**: `workspace_run`, `workspace_exec`, `workspace_install`
- **Quality**: `workspace_test`, `workspace_build`, `workspace_lint`, `workspace_typecheck`
- **Maintenance**: `workspace_clean`, `workspace_affected`
- **Guards**: `guards_install`, `guards_status`, `guards_uninstall`

Also updated `behavior.triggers` and `behavior.instruction` to reflect the expanded scope.

## Test plan

- [x] JSON is valid
- [x] `tools_index` entries match tool names in airis-workspace v3.18.0 `src/commands/mcp/mod.rs`
- [x] Related PR: agiletec-inc/airis-workspace#241

🤖 Generated with [Claude Code](https://claude.com/claude-code)