### PR TITLE
docs: update CLAUDE.md and README to reflect current architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,13 +12,36 @@ Dynamic MCP mode (default) exposes only 2 meta-tools (`airis-find`, `airis-schem
 
 Source of truth for server config: `mcp-config.json` (runtime) and `workflows/*.yaml` (compiled into MCP `initialize` instructions by `apps/api/src/app/core/behavior_compiler.py`).
 
+## Repo layout
+
+- `apps/api/` — Python 3.12 + FastAPI gateway (uv-managed). The actual MCP multiplexer.
+- `apps/gateway-control/` — TypeScript MCP server exposing gateway control tools to agents.
+- `apps/airis-commands/` (`@airis/commands`) — TypeScript MCP server bundling slash-command tooling.
+- `mcp-config.json` — runtime server registry (HOT/COLD, tools index, behavior).
+- `workflows/*.yaml` — compiled into MCP `initialize` instructions.
+- `manifest.toml` + `airis gen` produce `compose.yaml`, `package.json`, etc. Do not hand-edit generated files.
+
 ## Commands
 
 All commands use go-task inside `devbox shell`. Run `task --list-all` for the full list.
 
 Most used: `task docker:up` / `task docker:down` / `task docker:logs` / `task docker:restart` / `task test:e2e` / `task test:api`.
 
-Python tests locally without Docker: `cd apps/api && uv pip install -e ".[test]" && uv run python -m pytest tests/unit -v`.
+Test layout under `apps/api/tests/`:
+- `unit/` — pure logic, no network. Default target for `task test:api`.
+- `integration/` — exercises FastAPI app + ProcessManager with stubbed subprocesses.
+- `e2e/` — boots the full Docker stack and hits `localhost:9400`. Driven by `task test:e2e`.
+
+Python tests locally without Docker: `cd apps/api && uv pip install -e ".[test]" && uv run python -m pytest tests/unit -v`. Run a single test with `uv run python -m pytest tests/unit/test_foo.py::test_bar -v`.
+
+## Updating bundled `airis` CLI
+
+The gateway image bakes a specific `airis-workspace` release. To bump it:
+
+1. Edit `AIRIS_VERSION` in `apps/api/Dockerfile` (single source of truth — the version is pulled at build time from the airis-workspace GitHub release).
+2. `task docker:build` (or `docker compose build api`) — verify the Dockerfile download step succeeds.
+3. `task docker:up` and confirm `airis-workspace` tools resolve via `airis-find`.
+4. Commit `Dockerfile` only — there is no `package.json` pin to keep in sync.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ AIRIS is not only a central MCP registry. It also distributes operating guidance
 
 ## How It Works
 
-Airis aggregates 20+ MCP servers behind a single SSE endpoint. Your AI agent connects once and gets access to everything.
+Airis aggregates 20+ MCP servers behind a single endpoint — Streamable HTTP at `/mcp/` for Codex / Claude Code, and SSE at `/sse` for Gemini CLI, Cursor, and Windsurf. Your AI agent connects once and gets access to everything.
 
 ```
 Without Gateway:                          With Gateway:
@@ -142,35 +142,46 @@ Claude / Gemini / Cursor / Windsurf
 <details>
 <summary><h2>Available Servers</h2></summary>
 
-### Enabled (start on-demand)
+### HOT — pre-warmed at startup, always listed
 
 | Server | Description |
 |--------|-------------|
 | **context7** | Library documentation lookup |
-| **memory** | Knowledge graph (entities, relations) |
-| **tavily** | Web search via Tavily API |
-| **supabase** | Supabase database management |
-| **stripe** | Stripe payments API |
-| **fetch** | Web page fetching as markdown |
-| **sequential-thinking** | Step-by-step reasoning |
-| **serena** | Semantic code retrieval and editing |
-| **magic** | UI component generation |
-| **morphllm** | Code editing with warpgrep |
-| **chrome-devtools** | Chrome debugging |
+| **airis-workspace** | Docker-first workspace lifecycle (`manifest.toml` → `airis gen` → `airis up/test/...`) |
+| **airis-mcp-gateway-control** | Manage this gateway (servers, config, health) from inside the agent |
 
-### Disabled (auto-enable when called)
+### Enabled COLD — start on first tool call, auto-terminate when idle
 
 | Server | Description |
 |--------|-------------|
+| **airis-commands** | Slash-command toolkit shipped with the gateway |
+| **airis-legal** | Japanese court document automation (証拠説明書 / 準備書面) |
+| **fetch** | Fetch a URL and return it as markdown |
+| **tavily** | Web search via Tavily API |
+| **supabase** | Supabase database management |
+| **stripe** | Stripe payments API |
 | **twilio** | Twilio voice/SMS API |
-| **cloudflare** | Cloudflare management |
+| **cloudflare** | Cloudflare DNS / Workers / KV |
+| **figma** | Figma design files |
+| **magic** | UI component generation |
+| **chrome-devtools** | Chrome debugging |
+
+### Disabled — auto-enable on first tool call
+
+| Server | Description |
+|--------|-------------|
 | **github** | GitHub API |
 | **postgres** | Direct PostgreSQL access |
+| **memory** | Knowledge graph (entities, relations) |
+| **mindbase** | Local memory substrate (pgvector + Ollama) |
+| **serena** | Semantic code retrieval and editing |
+| **morphllm** | Code editing with warpgrep |
+| **sequential-thinking** | Step-by-step reasoning |
 | **filesystem** | File system operations |
 | **git** | Git operations |
 | **time** | Time utilities |
 
-All servers start on first tool call and auto-terminate when idle. Disabled servers are automatically enabled when you call their tools — no manual setup needed.
+Source of truth: [`mcp-config.json`](./mcp-config.json). HOT servers are always listed in `tools/list`; COLD servers are surfaced via `airis-find` and auto-enable on first native tool call — no manual setup needed.
 
 </details>
 


### PR DESCRIPTION
## Summary

ドキュメントを現状のアーキテクチャに合わせて更新。

- **CLAUDE.md**: repo layout セクション追加、テスト構成 (`unit`/`integration`/`e2e`) の内訳を明記、バンドルされた `airis` CLI のバージョン更新手順を追加
- **README.md**: dual-transport エンドポイント (Streamable HTTP `/mcp/` + SSE `/sse`) を明記、サーバー一覧を現行の HOT / COLD / Disabled 区分に刷新、`mcp-config.json` を source of truth として明示

ドキュメントのみの変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)