### PR TITLE
fix: standardize compose file references on compose.yaml (#135)

### DIFF
--- a/.claude/commands/troubleshoot.md
+++ b/.claude/commands/troubleshoot.md
@@ -40,10 +40,10 @@ Review @mcp-config.json for:
 
 | Symptom | Likely Cause | Fix |
 |---------|--------------|-----|
-| "Name or service not known" | DNS resolution | Check `dns:` in docker-compose.yml |
+| "Name or service not known" | DNS resolution | Check `dns:` in compose.yaml |
 | Tools timeout on first call | Cold start | Run `task test:prewarm` to check |
 | "Cannot find module" | Missing build | Run `task docker:build:nocache` |
-| Data lost on restart | No persistence | Check volume mounts in docker-compose.yml |
+| Data lost on restart | No persistence | Check volume mounts in compose.yaml |
 | Task not found | Not in devbox | Run `devbox shell` first |
 
 ## Output

--- a/.tasks.d/dev.yml
+++ b/.tasks.d/dev.yml
@@ -1,7 +1,7 @@
 version: '3'
 
 vars:
-  COMPOSE_FILE: "{{.REPO_ROOT}}/docker-compose.yml"
+  COMPOSE_FILE: "{{.REPO_ROOT}}/compose.yaml"
   COMPOSE_DEV_FILE: "{{.REPO_ROOT}}/docker-compose.dev.yml"
 
 tasks:

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -84,7 +84,7 @@ If you are migrating existing repositories, import and remove any repo-local `mc
 
 ## Resource Limits
 
-The default `docker-compose.yml` sets:
+The default `compose.yaml` sets:
 - Memory: 2GB
 - CPU: 2 cores
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-# NOTE: This file is NOT used by docker-compose.yml. The active build is
+# NOTE: This file is NOT used by compose.yaml. The active build is
 # apps/api/Dockerfile. This multi-stage definition is retained for external
 # tooling (e.g. `docker build --target measurement`). Base image tags are
 # pinned (issue #77) so that whatever still consumes it is reproducible.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,5 @@
 # Development overrides - hot reload and source mounts
-# Usage: docker compose -f docker-compose.yml -f docker-compose.dev.yml up
+# Usage: docker compose -f compose.yaml -f docker-compose.dev.yml up
 #
 # Prerequisites:
 #   - Build MCP servers locally first:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,7 +35,7 @@ Optional bearer token authentication. Disabled by default (open access).
 # Generate a secure API key
 openssl rand -hex 32
 
-# Set in .env or docker-compose.yml
+# Set in .env or compose.yaml
 AIRIS_API_KEY=your-generated-key
 ```
 
@@ -52,7 +52,7 @@ curl -H "Authorization: Bearer your-api-key" http://localhost:9400/health
 The gateway includes a configurable fail-safe timeout to prevent Claude Code from hanging indefinitely on frozen MCP tool calls:
 
 ```bash
-# In docker-compose.yml or .env
+# In compose.yaml or .env
 TOOL_CALL_TIMEOUT=90  # Default: 90 seconds
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -71,9 +71,9 @@ install() {
 
     check_dependencies
 
-    # Detect existing installation
+    # Detect existing installation (accept legacy docker-compose.yml name)
     local is_update=false
-    if [ -f "$DIR/docker-compose.yml" ]; then
+    if [ -f "$DIR/compose.yaml" ] || [ -f "$DIR/docker-compose.yml" ]; then
         is_update=true
         log_info "Existing installation detected. Updating..."
     fi
@@ -82,7 +82,9 @@ install() {
     log_step "1/4 Downloading configuration..."
     mkdir -p "$DIR"
 
-    download "$BASE_URL/docker-compose.dist.yml" "$DIR/docker-compose.yml"
+    download "$BASE_URL/docker-compose.dist.yml" "$DIR/compose.yaml"
+    # Drop the legacy filename so Docker Compose does not auto-discover two files
+    rm -f "$DIR/docker-compose.yml"
 
     # Only download mcp-config if not exists (preserve user customizations)
     if [ ! -f "$DIR/mcp-config.json" ]; then
@@ -187,7 +189,7 @@ install() {
     echo ""
     echo "  Files:"
     echo "    Config:  $DIR/mcp-config.json"
-    echo "    Compose: $DIR/docker-compose.yml"
+    echo "    Compose: $DIR/compose.yaml"
     echo ""
     echo "  CLI: airis-gateway"
     if ! $path_ok; then
@@ -256,8 +258,8 @@ uninstall() {
         claude mcp remove airis-mcp-gateway --scope user 2>/dev/null || true
     fi
 
-    # Stop containers
-    if [ -f "$DIR/docker-compose.yml" ]; then
+    # Stop containers (accept legacy docker-compose.yml name)
+    if [ -f "$DIR/compose.yaml" ] || [ -f "$DIR/docker-compose.yml" ]; then
         log_step "Stopping containers..."
         cd "$DIR"
         docker compose down -v 2>/dev/null || true

--- a/ops/autostart/linux/airis-mcp-gateway.service.tmpl
+++ b/ops/autostart/linux/airis-mcp-gateway.service.tmpl
@@ -7,8 +7,8 @@ Requires=docker.service
 Type=oneshot
 RemainAfterExit=yes
 WorkingDirectory={{REPO_ROOT}}
-ExecStart=/usr/bin/docker compose -f {{REPO_ROOT}}/docker-compose.yml up -d
-ExecStop=/usr/bin/docker compose -f {{REPO_ROOT}}/docker-compose.yml down
+ExecStart=/usr/bin/docker compose -f {{REPO_ROOT}}/compose.yaml up -d
+ExecStop=/usr/bin/docker compose -f {{REPO_ROOT}}/compose.yaml down
 User={{USER}}
 Group={{USER}}
 

--- a/ops/autostart/macos/com.agiletec.airis-mcp-gateway.plist.tmpl
+++ b/ops/autostart/macos/com.agiletec.airis-mcp-gateway.plist.tmpl
@@ -9,7 +9,7 @@
     <array>
         <string>{{DOCKER_COMPOSE_PATH}}</string>
         <string>-f</string>
-        <string>{{REPO_ROOT}}/docker-compose.yml</string>
+        <string>{{REPO_ROOT}}/compose.yaml</string>
         <string>up</string>
         <string>-d</string>
     </array>

--- a/ops/autostart/macos/install.sh
+++ b/ops/autostart/macos/install.sh
@@ -119,7 +119,7 @@ cat > "$PLIST_DEST" << EOF
         <string>$DOCKER_COMPOSE_PATH</string>
         <string>compose</string>
         <string>-f</string>
-        <string>$REPO_ROOT/docker-compose.yml</string>
+        <string>$REPO_ROOT/compose.yaml</string>
         <string>up</string>
         <string>-d</string>
     </array>

--- a/scripts/airis-gateway
+++ b/scripts/airis-gateway
@@ -102,9 +102,11 @@ sync_codex_registration() {
 
 ensure_files() {
     mkdir -p "$DIR"
-    if [ ! -f "$DIR/docker-compose.yml" ]; then
-        log_info "Downloading docker-compose.yml..."
-        curl -fsSL "$BASE_URL/docker-compose.dist.yml" -o "$DIR/docker-compose.yml"
+    # Drop the legacy filename so Docker Compose does not auto-discover two files
+    [ -f "$DIR/docker-compose.yml" ] && rm -f "$DIR/docker-compose.yml"
+    if [ ! -f "$DIR/compose.yaml" ]; then
+        log_info "Downloading compose.yaml..."
+        curl -fsSL "$BASE_URL/docker-compose.dist.yml" -o "$DIR/compose.yaml"
     fi
     if [ ! -f "$DIR/mcp-config.json" ]; then
         log_info "Downloading default config..."
@@ -677,7 +679,7 @@ case "${1:-help}" in
         if command -v claude >/dev/null 2>&1; then
             claude mcp remove airis-mcp-gateway --scope user 2>/dev/null || true
         fi
-        if [ -f "$DIR/docker-compose.yml" ]; then
+        if [ -f "$DIR/compose.yaml" ] || [ -f "$DIR/docker-compose.yml" ]; then
             cd "$DIR" && docker compose down -v 2>/dev/null || true
         fi
         [ -d "$DIR" ] && rm -rf "$DIR" && log_info "Removed $DIR"


### PR DESCRIPTION
## 背景

issue #135: ルートに `compose.yaml`（未トラック）と `docker-compose.yml`（本番）が共存し、Docker Compose が誤ったファイルを選択する問題。

PR #146 でルートの `docker-compose.yml` → `compose.yaml` にリネームされ競合自体は解消されたが、**`docker-compose.yml` を指す古い参照が repo 全体に残っていた**ため、別の機能が壊れていた。

## 修正内容

### 機能的バグ（壊れていたもの）
- **`.tasks.d/dev.yml`**: `COMPOSE_FILE` が存在しない `docker-compose.yml` を参照 → `task dev:up` / `dev:down` / `dev:restart` / `dev:logs` が全滅
- **macOS LaunchAgent / Linux systemd テンプレート**: 存在しないファイルを参照 → autostart が起動しない

### スタンドアロンインストーラ
- `install.sh` / `scripts/airis-gateway` が dist compose を `compose.yaml` としてダウンロードするよう変更
- リネーム前にインストール済みのユーザー向けに、レガシーな `docker-compose.yml` を削除する移行処理を追加（インストールディレクトリで2ファイルが auto-discovery されるのを防止）
- 既存インストール検出・アンインストール処理は新旧どちらのファイル名も受け付ける

### ドキュメント・コメント
- `Dockerfile`, `DEPLOYMENT.md`, `docs/configuration.md`, `troubleshoot.md`, `docker-compose.dev.yml` ヘッダの古い参照を更新

## 検証

`docker compose -f compose.yaml [-f docker-compose.dev.yml] config` が正常に解決することを確認済み。

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)