### PR TITLE
test: add compose-file reference regression test (#135)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,12 @@ jobs:
               - 'scripts/airis-gateway'
               - 'scripts/quick-install.sh'
               - 'scripts/test-airis-gateway-smoke.sh'
+              - 'scripts/test-compose-references.sh'
               - 'install.sh'
               - '.tasks.d/test.yml'
+              - '.tasks.d/dev.yml'
+              - 'compose.yaml'
+              - 'ops/autostart/**'
               - '.github/workflows/ci.yml'
 
   # Python tests (only when Python files change)
@@ -134,4 +138,7 @@ jobs:
 
       - name: Run airis-gateway smoke tests
         run: bash scripts/test-airis-gateway-smoke.sh
+
+      - name: Run compose reference tests
+        run: bash scripts/test-compose-references.sh
 

--- a/scripts/test-compose-references.sh
+++ b/scripts/test-compose-references.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Regression test for issue #135: compose-file reference drift.
+#
+# PR #146 renamed the root docker-compose.yml to compose.yaml but left stale
+# references to the old name in task configs and autostart templates, which
+# silently broke `task dev:*` and OS autostart. This test fails if any
+# REPO_ROOT-relative compose reference points at a file that does not exist,
+# or if a second auto-discoverable compose file reappears at the repo root.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# 1. The canonical compose file exists at the repo root.
+[ -f "$ROOT_DIR/compose.yaml" ] || fail "compose.yaml missing at repo root"
+
+# 2. No docker-compose.yml at the root. Two auto-discovered names would make
+#    Docker Compose pick the wrong file — the original issue #135 symptom.
+[ -e "$ROOT_DIR/docker-compose.yml" ] && \
+    fail "docker-compose.yml present at repo root — auto-discovery conflict with compose.yaml"
+
+# 3. Every "<REPO_ROOT>/<file>.ya?ml" compose reference resolves to a real file.
+#    Covers both `{{.REPO_ROOT}}` (go-task) and `{{REPO_ROOT}}` (autostart
+#    templates) — the shared "REPO_ROOT}}/" substring matches either form.
+check_file_refs() {
+    local where="$1" refs ref
+    refs="$(grep -oE 'REPO_ROOT}}/[A-Za-z0-9._/-]+\.ya?ml' "$ROOT_DIR/$where" \
+        | sed 's#.*REPO_ROOT}}/##' | sort -u)"
+    [ -n "$refs" ] || fail "$where: no REPO_ROOT-relative compose reference found"
+    while IFS= read -r ref; do
+        [ -f "$ROOT_DIR/$ref" ] || \
+            fail "$where references '$ref' which does not exist at repo root"
+    done <<< "$refs"
+}
+
+check_file_refs ".tasks.d/dev.yml"
+check_file_refs "ops/autostart/macos/com.agiletec.airis-mcp-gateway.plist.tmpl"
+check_file_refs "ops/autostart/linux/airis-mcp-gateway.service.tmpl"
+
+echo "compose reference tests passed"


### PR DESCRIPTION
## 背景

issue #135 / PR #152 で、`compose.yaml` リネーム時に取り残された `docker-compose.yml` 参照を修正した。本 PR はそのドリフトが再発しないよう**回帰テストを追加**する（PR #152 ではテストが未整備だったための follow-up）。

## 追加内容

`scripts/test-compose-references.sh` — 以下を検証:
- ルートに `compose.yaml` が存在する
- ルートに `docker-compose.yml` が**存在しない**（auto-discovery 競合ガード = issue #135 の元症状）
- `.tasks.d/dev.yml` および macOS/Linux autostart テンプレート内の `REPO_ROOT` 相対の compose 参照が、すべて実在するファイルを指す

既存の `test-shell` CI ジョブにステップを追加。`shell` paths-filter に `.tasks.d/dev.yml` / `compose.yaml` / `ops/autostart/**` / 新スクリプトを追加し、関連変更で発火するようにした。

## 検証

- 修正後の状態 → **pass**
- 修正前の状態を再現（`dev.yml` を存在しない `docker-compose.yml` に戻す）→ **正しく FAIL**（`FAIL: .tasks.d/dev.yml references 'docker-compose.yml' which does not exist`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)