### PR TITLE
ci: add CodeQL static analysis workflow (#94)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,46 @@
+name: CodeQL
+
+# Static analysis (SAST) for Python and JS/TS sources — issue #94.
+# Dependency scanning (pip-audit / npm audit) lives in ci.yml; this workflow
+# adds code-level vulnerability detection on top of it.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    # Weekly full scan to catch newly published CodeQL queries on dormant code.
+    - cron: '23 5 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - python
+          - javascript-typescript
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # Python and JS/TS are interpreted — no compilation step needed.
+          build-mode: none
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## 背景

issue #94: CI に依存関係脆弱性スキャン・SAST が不足している。

調査の結果、remediation のうち以下は **既に対応済み**:
- Python 依存監査 (`pip-audit`) — `ci.yml` の `test-python` ジョブ
- Node.js 依存監査 (`npm audit --audit-level=high`) — `ci.yml` の `build-typescript` ジョブ
- Python SAST (`bandit`) — `ci.yml`

残る remediation 項目は **GitHub CodeQL**（コードレベルの脆弱性スキャン）。

## 変更内容

`.github/workflows/codeql.yml` を新規追加:
- `python` と `javascript-typescript` の両方を解析（matrix）
- `main` への push / PR、および週次のスケジュールスキャンで実行
- `build-mode: none`（両言語ともインタプリタ型でビルド不要）
- 結果はリポジトリの Security タブに表示

## スコープ外

コンテナイメージスキャン（trivy/grype）は issue の現状テーブルには記載があるが remediation ステップには含まれていないため、本 PR では対象外（必要なら follow-up）。

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)