### PR TITLE
fix(compose): clear OrbStack proxy vars on the gateway service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,10 @@ ENCRYPTION_MASTER_KEY=your-32-byte-base64-encoded-key-here
 # Create token at https://github.com/settings/tokens
 # GITHUB_TOKEN=ghp_xxx
 
+# Figma - Design file access
+# Create a personal access token at https://www.figma.com/developers/api#access-tokens
+# FIGMA_API_KEY=figd_xxx
+
 # Magic (21st.dev) - UI component generation
 # Get your API key at https://21st.dev
 # MAGIC_API_KEY=xxx

--- a/README.md
+++ b/README.md
@@ -36,11 +36,15 @@ docker compose up -d
 docker compose logs -f api
 ```
 
-> **Tip:** For secure secret management, use [Doppler](https://doppler.com) instead of `.env`:
+> **Tip:** With access to the team [Doppler](https://doppler.com) project you can
+> bulk-fill the API keys instead of pasting them one by one. Run this right after
+> `cp .env.example .env`:
 > ```bash
-> doppler setup                              # One-time setup
-> doppler run -- docker compose up -d        # Injects secrets at runtime
+> doppler secrets download --project airis-mcp-gateway --config dev \
+>   --format env --no-file >> .env
 > ```
+> `.env` is gitignored and loaded directly by `docker compose` — no `doppler run`
+> runtime injection needed.
 
 ### 2. Connect Your AI Client
 Register the gateway once, and access all backend MCP servers (Stripe, Supabase, GitHub, etc.) through a single connection.

--- a/compose.yaml
+++ b/compose.yaml
@@ -61,6 +61,19 @@ services:
       - --watch
       - --additional-catalog=/catalogs/airis-catalog.yaml
       - --servers=time,mindbase
+    environment:
+      # Clear OrbStack-injected proxy vars. docker/mcp-gateway fetches its
+      # catalog over HTTPS; the injected proxy host (proxyproxy.orb.internal)
+      # does not resolve, which crash-loops the container. Same fix the api
+      # service already carries — issue: it was applied there but not here.
+      - HTTP_PROXY=
+      - HTTPS_PROXY=
+      - ALL_PROXY=
+      - NO_PROXY=
+      - http_proxy=
+      - https_proxy=
+      - all_proxy=
+      - no_proxy=
     expose:
       - "9390"
     volumes:


### PR DESCRIPTION
## 問題

`docker compose up` で `gateway` コンテナ（`airis-mcp-gateway-core` / docker/mcp-gateway）が **exit 1 で 180 回クラッシュループ**していた。

```
reading catalog: Get "https://desktop.docker.com/mcp/catalog/v3/catalog.yaml":
  proxyconnect tcp: dial tcp: lookup proxyproxy.orb.internal: no such host
```

OrbStack が注入する `HTTP_PROXY=http://proxyproxy.orb.internal:8305` 等が `gateway` コンテナに残存し、カタログの HTTPS 取得が解決不能プロキシ経由で失敗 → プロセス終了。

## 原因

コミット `431a6bdf "fix ... OrbStack proxy issues"` がプロキシ除去ブロックを **`api` サービスにだけ**追加し、`gateway` サービスを入れ忘れた中途半端な修正だった。

## 修正

- `compose.yaml`：`api` と同じ OrbStack プロキシ除去ブロックを `gateway` サービスにも適用
- `README.md`：このリポジトリはローカル開発ツールなので、Doppler ランタイム注入（`doppler run --`）の案内をやめ、`.env` への一括ダウンロード方式に変更
- `.env.example`：`compose.yaml` が参照しているのにテンプレートに欠けていた `FIGMA_API_KEY` を追加

## 検証

`docker compose up -d` → 全4コンテナ healthy、`/health` 200、`/ready` が `ready:true`（hot servers 3/3）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)