### PR TITLE
refactor(compose): rename docker/mcp-gateway service to docker-mcp-gateway

### DIFF
--- a/assets/demo-script.sh
+++ b/assets/demo-script.sh
@@ -29,10 +29,10 @@ section "# 1. Start the gateway"
 fake_type '$ docker compose up -d'
 sleep 0.3
 printf "${COLOR_DIM}[+] Running 4/4${COLOR_RESET}\n"
-printf " ${COLOR_GREEN}✔${COLOR_RESET} Container mindbase-postgres-dev  ${COLOR_GREEN}Healthy${COLOR_RESET}\n"
-printf " ${COLOR_GREEN}✔${COLOR_RESET} Container airis-mcp-gateway-core ${COLOR_GREEN}Healthy${COLOR_RESET}\n"
-printf " ${COLOR_GREEN}✔${COLOR_RESET} Container airis-serena           ${COLOR_GREEN}Healthy${COLOR_RESET}\n"
-printf " ${COLOR_GREEN}✔${COLOR_RESET} Container airis-mcp-gateway      ${COLOR_GREEN}Healthy${COLOR_RESET}\n"
+printf " ${COLOR_GREEN}✔${COLOR_RESET} Container mindbase-postgres-dev     ${COLOR_GREEN}Healthy${COLOR_RESET}\n"
+printf " ${COLOR_GREEN}✔${COLOR_RESET} Container airis-docker-mcp-gateway  ${COLOR_GREEN}Healthy${COLOR_RESET}\n"
+printf " ${COLOR_GREEN}✔${COLOR_RESET} Container airis-serena              ${COLOR_GREEN}Healthy${COLOR_RESET}\n"
+printf " ${COLOR_GREEN}✔${COLOR_RESET} Container airis-mcp-gateway         ${COLOR_GREEN}Healthy${COLOR_RESET}\n"
 sleep 1.5
 
 # Step 2

--- a/compose.yaml
+++ b/compose.yaml
@@ -50,8 +50,8 @@ services:
 
   # Docker MCP Gateway (internal, port 9390)
   # Manages MCP servers from Docker catalog (time, mindbase via stdio)
-  gateway:
-    container_name: airis-mcp-gateway-core
+  docker-mcp-gateway:
+    container_name: airis-docker-mcp-gateway
     # Pinned by digest — docker/mcp-gateway does not publish versioned tags (issue #77).
     # Refresh: docker pull docker/mcp-gateway:latest && docker inspect --format='{{index .RepoDigests 0}}' docker/mcp-gateway:latest
     image: docker/mcp-gateway@sha256:f79574a3f86603ad65fd5c04f1251a2f2ecda56c1df76ed4418c1c11401c9432
@@ -105,7 +105,7 @@ services:
     mem_limit: 2g
     cpus: 2
     environment:
-      - MCP_GATEWAY_URL=http://gateway:9390
+      - MCP_GATEWAY_URL=http://docker-mcp-gateway:9390
       - MCP_CONFIG_PATH=/app/mcp-config.json
       - GATEWAY_CONFIG_PATH=/app/config/gateway-config.yaml
       # Dynamic MCP: exposes only meta-tools instead of all tools
@@ -143,7 +143,7 @@ services:
       - ./config/gateway-config.yaml:/app/config/gateway-config.yaml:ro
       - ./profiles:/app/profiles:rw
       # Host workspace for airis-workspace tools (workspace_init / workspace_status etc.).
-      # Same convention as the mcp-core "gateway" service above.
+      # Same convention as the docker-mcp-gateway service above.
       - ${HOST_WORKSPACE_DIR:-${HOME}/github}:/workspace:rw
       # Persistent data volumes (appuser home directory)
       - cache-uv:/home/appuser/.cache/uv   # uvx package cache (faster restarts)
@@ -152,7 +152,7 @@ services:
       # Host Claude Code config for airis-commands rules/settings management
       - ${HOME}/.claude:/host-claude:rw
     depends_on:
-      gateway:
+      docker-mcp-gateway:
         condition: service_healthy
       serena:
         condition: service_started

--- a/docker-compose.dist.yml
+++ b/docker-compose.dist.yml
@@ -33,8 +33,8 @@ services:
     restart: unless-stopped
 
   # Docker MCP Gateway (manages MCP servers from Docker catalog)
-  gateway:
-    container_name: airis-mcp-gateway-core
+  docker-mcp-gateway:
+    container_name: airis-docker-mcp-gateway
     image: docker/mcp-gateway:latest
     command:
       - --transport=sse
@@ -60,7 +60,7 @@ services:
     ports:
       - "9400:8000"
     environment:
-      - MCP_GATEWAY_URL=http://gateway:9390
+      - MCP_GATEWAY_URL=http://docker-mcp-gateway:9390
       - MCP_CONFIG_PATH=/app/mcp-config.json
       # Embedded mode (default): mindbase runs locally
       # Remote mode: set URLs to external services
@@ -71,7 +71,7 @@ services:
       - ./mcp-config.json:/app/mcp-config.json:ro
       - ./profiles:/app/profiles:rw
     depends_on:
-      gateway:
+      docker-mcp-gateway:
         condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:8000/health || exit 1"]

--- a/infra/compose.yaml
+++ b/infra/compose.yaml
@@ -51,7 +51,7 @@ services:
     ports:
       - "${GATEWAY_PORT:-9400}:8000"
     environment:
-      - MCP_GATEWAY_URL=http://mcp-core:9390
+      - MCP_GATEWAY_URL=http://docker-mcp-gateway:9390
       - MCP_CONFIG_PATH=/app/mcp-config.json
       - DATABASE_URL=postgresql://${POSTGRES_USER:-airis}:${POSTGRES_PASSWORD:-airis}@postgres:5432/${POSTGRES_DB:-airis}
     volumes:
@@ -63,7 +63,7 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-      mcp-core:
+      docker-mcp-gateway:
         condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:8000/health || exit 1"]
@@ -72,9 +72,9 @@ services:
       retries: 5
     restart: unless-stopped
 
-  # Docker MCP Gateway Core (internal)
-  mcp-core:
-    container_name: airis-mcp-core
+  # Docker MCP Gateway (internal)
+  docker-mcp-gateway:
+    container_name: airis-docker-mcp-gateway
     image: docker/mcp-gateway:latest
     command:
       - --transport=sse
@@ -158,12 +158,12 @@ volumes:
 #
 # Lite (default):
 #   docker compose -f infra/compose.yaml up -d
-#   - postgres, mcp-core, gateway
+#   - postgres, docker-mcp-gateway, gateway
 #   - Gateway routes to process-based MCP servers (uvx/npx)
 #
 # Full:
 #   docker compose -f infra/compose.yaml --profile full up -d
-#   - postgres, mcp-core, gateway, agent, mindbase
+#   - postgres, docker-mcp-gateway, gateway, agent, mindbase
 #   - All services as Docker containers
 #
 # With Serena:


### PR DESCRIPTION
## 背景

docker/mcp-gateway 公式イメージを動かすコンテナの命名が中途半端なリファクタで不整合だった：

- `compose.yaml`：サービス `gateway` / コンテナ `airis-mcp-gateway-core`
- `infra/compose.yaml`：サービス `mcp-core` / コンテナ `airis-mcp-core`

`core`（命名ルールで禁止語）が残り、さらにサービス名 `gateway` はプロダクト自体も gateway なので曖昧。

## 修正

責務ベースで命名 — このコンテナは **Docker MCP Gateway そのもの**：

- サービスキー：`gateway` / `mcp-core` → **`docker-mcp-gateway`**
- `container_name`：`airis-mcp-gateway-core` / `airis-mcp-core` → **`airis-docker-mcp-gateway`**
- `MCP_GATEWAY_URL` / `depends_on` / コメントを追従更新
- `docker-compose.dist.yml` / `assets/demo-script.sh` にも同じ改名を適用

`compose.yaml` の `api`、`serena` 等は責務明確・衝突なしのため変更なし。

## 検証

`docker compose up -d` → 旧 `airis-mcp-gateway-core` は除去され `airis-docker-mcp-gateway` が healthy、全コンテナ healthy、`/ready` が `gateway: ok`。3 compose ファイルとも `docker compose config` 通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)