### PR TITLE
ci: enforce GitHub-hosted runners on this public repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,16 @@ on:
       - main
 
 jobs:
+  # airis-mcp-gateway is a PUBLIC repo — every job must run on a GitHub-hosted
+  # runner. This guard runs unconditionally (no path filter) so it can serve as
+  # a required status check that blocks any PR introducing a self-hosted runner.
+  verify-runners:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Verify all workflows use GitHub-hosted runners
+        run: bash scripts/test-workflow-runners.sh
+
   # Detect which paths changed
   changes:
     runs-on: ubuntu-latest

--- a/scripts/test-workflow-runners.sh
+++ b/scripts/test-workflow-runners.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Guard: airis-mcp-gateway is a PUBLIC repository, so every GitHub Actions job
+# must run on a GitHub-hosted runner (ubuntu-*, macos-*, windows-*).
+#
+# Self-hosted runners on a public repo let any fork pull request execute code
+# on the runner host — GitHub's own guidance says self-hosted runners should
+# "almost never be used for public repositories". This script fails CI if any
+# workflow declares a non-hosted `runs-on`, so the policy cannot regress.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKFLOW_DIR="$ROOT_DIR/.github/workflows"
+
+if [ ! -d "$WORKFLOW_DIR" ]; then
+    echo "no .github/workflows directory — nothing to check"
+    exit 0
+fi
+
+bad=0
+checked=0
+
+for wf in "$WORKFLOW_DIR"/*.yml "$WORKFLOW_DIR"/*.yaml; do
+    [ -e "$wf" ] || continue
+    name="$(basename "$wf")"
+
+    # Extract every `runs-on:` value. Handles `runs-on: x`, quoted values and
+    # inline arrays `runs-on: [a, b]`; emits one normalised value per line.
+    values="$(grep -E '^[[:space:]]*runs-on:' "$wf" \
+        | sed -E 's/.*runs-on:[[:space:]]*//' \
+        | tr -d '[]"'"'" \
+        | tr ',' '\n' \
+        | sed -E 's/^[[:space:]]*//; s/[[:space:]]*$//' \
+        | grep -v '^$' || true)"
+
+    [ -z "$values" ] && continue
+
+    while IFS= read -r value; do
+        checked=$((checked + 1))
+        case "$value" in
+            ubuntu-* | macos-* | windows-*)
+                ;;  # GitHub-hosted — OK
+            *)
+                echo "FAIL: $name declares runs-on '$value' — not a GitHub-hosted runner" >&2
+                bad=1
+                ;;
+        esac
+    done <<< "$values"
+done
+
+if [ "$bad" -ne 0 ]; then
+    {
+        echo ""
+        echo "airis-mcp-gateway is a PUBLIC repository: every job must use a"
+        echo "GitHub-hosted runner (ubuntu-*, macos-*, windows-*). Self-hosted"
+        echo "runners are forbidden here — a fork pull request could run code on"
+        echo "the runner host. See GitHub's secure-use guidance."
+    } >&2
+    exit 1
+fi
+
+echo "workflow runner tests passed — $checked job(s), all GitHub-hosted"


### PR DESCRIPTION
## 背景

`airis-mcp-gateway` は public リポジトリ。public repo でセルフホストランナーを使うと、fork からの PR が任意コードをランナーホスト（自宅サーバー）上で実行できてしまう。GitHub 公式も「self-hosted runners should almost never be used for public repositories」と明言している。

現状は全ワークフローが `ubuntu-latest`（GitHub ホステッド）だが、**機械的に弾く仕組みが無く**、将来 `runs-on: self-hosted` や ARC ラベルに drift しても気付けなかった。

## 変更（L2: repo 内 CI ガード）

- `scripts/test-workflow-runners.sh`：`.github/workflows/*` の全 `runs-on` を走査し、GitHub ホステッド（`ubuntu-*` / `macos-*` / `windows-*`）以外があれば CI を fail。`self-hosted` 配列だけでなく、`self-hosted` 文字列を含まない ARC ラベル（例 `ci-cd-burst`）も検出する。
- `ci.yml`：`verify-runners` ジョブを追加。**パスフィルタ無しで常時実行**するため、この後ステータスチェック必須化（repo ruleset）の対象にできる。

## 検証

- 現行5ワークフロー8ジョブ → pass。
- `runs-on: [self-hosted, ...]` 注入 → 正しく FAIL。
- `runs-on: ci-cd-burst`（ARC ラベル）注入 → 正しく FAIL。

これは public repo でセルフホストランナーを禁止する3層対策の L2。L3（repo ruleset で `verify-runners` を必須チェック化）が続く。

🤖 Generated with [Claude Code](https://claude.com/claude-code)