### PR TITLE
test: cover database and protocol_logger core modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,9 +77,12 @@ jobs:
           uv pip install --system -e ".[test]"
 
       - name: Run tests with coverage
+        # --cov-fail-under is a regression ratchet, not the end goal. It must
+        # never be lowered — raise it as coverage improves. Target is 70%
+        # (issue #85); bump this number in the same PR that adds the tests.
         run: |
           cd apps/api
-          python -m pytest tests/unit -v --tb=short --cov=src --cov-report=xml --cov-report=term-missing
+          python -m pytest tests/unit -v --tb=short --cov=src --cov-report=xml --cov-report=term-missing --cov-fail-under=48
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6

--- a/apps/api/tests/unit/test_database.py
+++ b/apps/api/tests/unit/test_database.py
@@ -1,0 +1,118 @@
+"""Tests for the database module (issue #85).
+
+database.py selects one of three mode branches at import time, driven by
+GATEWAY_MODE / DATABASE_URL env vars and SQLAlchemy availability. These
+tests exercise each branch by reloading the module under controlled
+conditions, always restoring the original lite-mode state afterward so
+the rest of the suite is unaffected.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+
+import pytest
+
+import app.core.database as db_mod
+
+
+@pytest.fixture
+def reload_database():
+    """Reload database.py with controlled env / SQLAlchemy availability.
+
+    Yields a callable. On teardown it restores the original env vars,
+    sys.modules entries, and reloads the module so other tests keep
+    seeing the default lite-mode module.
+    """
+    env_keys = ("GATEWAY_MODE", "DATABASE_URL")
+    saved_env = {key: os.environ.get(key) for key in env_keys}
+    sa_modules = ("sqlalchemy", "sqlalchemy.ext.asyncio", "sqlalchemy.orm")
+    saved_modules = {name: sys.modules.get(name) for name in sa_modules}
+
+    def _reload(*, gateway_mode=None, database_url=None, block_sqlalchemy=False):
+        for key, value in (("GATEWAY_MODE", gateway_mode), ("DATABASE_URL", database_url)):
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        if block_sqlalchemy:
+            # Setting a module to None in sys.modules makes `import` raise ImportError.
+            for name in sa_modules:
+                sys.modules[name] = None
+        importlib.reload(db_mod)
+        return db_mod
+
+    yield _reload
+
+    for name, module in saved_modules.items():
+        if module is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = module
+    for key, value in saved_env.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+    importlib.reload(db_mod)
+
+
+async def _first_yield(async_gen):
+    """Return the first value produced by an async generator, then close it."""
+    try:
+        return await async_gen.__anext__()
+    finally:
+        await async_gen.aclose()
+
+
+@pytest.mark.asyncio
+async def test_lite_mode_with_sqlalchemy(reload_database):
+    """Lite mode: SQLAlchemy present but no DATABASE_URL — no engine, no sessions."""
+    mod = reload_database(gateway_mode="lite", database_url=None)
+
+    assert mod.is_db_available() is False
+    assert mod.engine is None
+    assert mod.AsyncSessionLocal is None
+    assert await _first_yield(mod.get_db()) is None
+    # Base is a real declarative base usable for model metadata.
+    assert hasattr(mod.Base, "metadata")
+
+
+@pytest.mark.asyncio
+async def test_full_mode_creates_engine(reload_database):
+    """Full mode: GATEWAY_MODE=full + DATABASE_URL builds a real engine and sessions."""
+    mod = reload_database(
+        gateway_mode="full",
+        database_url="sqlite+aiosqlite:///:memory:",
+    )
+
+    assert mod.is_db_available() is True
+    assert mod.engine is not None
+    assert mod.AsyncSessionLocal is not None
+
+    session = await _first_yield(mod.get_db())
+    assert session is not None
+    await mod.engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_full_mode_requires_database_url(reload_database):
+    """GATEWAY_MODE=full without DATABASE_URL stays in lite mode."""
+    mod = reload_database(gateway_mode="full", database_url=None)
+
+    assert mod.is_db_available() is False
+    assert mod.engine is None
+
+
+@pytest.mark.asyncio
+async def test_no_sqlalchemy_falls_back_to_stub_base(reload_database):
+    """Without SQLAlchemy the module exposes a stub Base and no DB access."""
+    mod = reload_database(block_sqlalchemy=True)
+
+    assert mod.is_db_available() is False
+    assert mod.engine is None
+    assert mod.AsyncSessionLocal is None
+    assert await _first_yield(mod.get_db()) is None
+    # The stub Base is a plain class — it has no SQLAlchemy metadata.
+    assert not hasattr(mod.Base, "metadata")

--- a/apps/api/tests/unit/test_protocol_logger.py
+++ b/apps/api/tests/unit/test_protocol_logger.py
@@ -1,0 +1,172 @@
+"""Tests for ProtocolLogger (issue #85).
+
+ProtocolLogger appends MCP protocol messages to a JSONL file. These tests
+cover directory resolution (including the /tmp fallback), the entry shape
+written by log_message, the request/response helper methods, and log
+clearing.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.core.protocol_logger import ProtocolLogger
+
+
+@pytest.fixture(autouse=True)
+def _no_protocol_log_dir_env(monkeypatch):
+    """Ensure a stray PROTOCOL_LOG_DIR in the environment never leaks into tests."""
+    monkeypatch.delenv("PROTOCOL_LOG_DIR", raising=False)
+
+
+def _read_entries(logger: ProtocolLogger) -> list[dict]:
+    """Parse the logger's JSONL file into a list of entries."""
+    return [
+        json.loads(line)
+        for line in logger.log_file.read_text().splitlines()
+        if line.strip()
+    ]
+
+
+def test_init_creates_log_dir(tmp_path):
+    target = tmp_path / "logs"
+
+    logger = ProtocolLogger(log_dir=target)
+
+    assert logger.log_dir == target
+    assert target.is_dir()
+    assert logger.log_file == target / "protocol_messages.jsonl"
+
+
+def test_init_respects_protocol_log_dir_env(tmp_path, monkeypatch):
+    env_dir = tmp_path / "from_env"
+    monkeypatch.setenv("PROTOCOL_LOG_DIR", str(env_dir))
+
+    # The env var overrides the constructor argument.
+    logger = ProtocolLogger(log_dir=tmp_path / "ignored")
+
+    assert logger.log_dir == env_dir
+    assert env_dir.is_dir()
+
+
+def test_ensure_log_dir_falls_back_when_uncreatable(tmp_path):
+    # A regular file cannot host a child directory — mkdir raises OSError.
+    blocker = tmp_path / "blocker"
+    blocker.write_text("not a directory")
+    unusable = blocker / "logs"
+
+    logger = ProtocolLogger(log_dir=unusable)
+
+    assert logger.log_dir != unusable
+    assert logger.log_dir.is_dir()
+
+
+@pytest.mark.asyncio
+async def test_log_message_writes_jsonl_entry(tmp_path):
+    logger = ProtocolLogger(log_dir=tmp_path)
+
+    await logger.log_message(
+        "client→server",
+        {"jsonrpc": "2.0", "id": 7, "method": "tools/list"},
+    )
+
+    entries = _read_entries(logger)
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["direction"] == "client→server"
+    assert entry["method"] == "tools/list"
+    assert entry["id"] == 7
+    assert entry["has_result"] is False
+    assert entry["has_error"] is False
+    assert "metadata" not in entry
+    assert "timestamp" in entry
+
+
+@pytest.mark.asyncio
+async def test_log_message_includes_metadata_and_result_flags(tmp_path):
+    logger = ProtocolLogger(log_dir=tmp_path)
+
+    await logger.log_message(
+        "server→client",
+        {"jsonrpc": "2.0", "id": 7, "result": {"tools": []}},
+        metadata={"server": "context7"},
+    )
+
+    entry = _read_entries(logger)[0]
+    assert entry["has_result"] is True
+    assert entry["has_error"] is False
+    assert entry["metadata"] == {"server": "context7"}
+
+
+@pytest.mark.asyncio
+async def test_log_message_appends_successive_entries(tmp_path):
+    logger = ProtocolLogger(log_dir=tmp_path)
+
+    await logger.log_message("client→server", {"id": 1})
+    await logger.log_message("client→server", {"id": 2})
+
+    assert [e["id"] for e in _read_entries(logger)] == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_log_initialize_writes_request_and_response(tmp_path):
+    logger = ProtocolLogger(log_dir=tmp_path)
+
+    await logger.log_initialize(
+        {"id": 1, "method": "initialize"},
+        {"id": 1, "result": {}},
+    )
+
+    entries = _read_entries(logger)
+    assert [e["direction"] for e in entries] == ["client→server", "server→client"]
+    assert all(e["metadata"]["phase"] == "initialize" for e in entries)
+
+
+@pytest.mark.asyncio
+async def test_log_tools_list_records_pattern(tmp_path):
+    logger = ProtocolLogger(log_dir=tmp_path)
+
+    await logger.log_tools_list({"id": 1}, {"id": 1, "result": {}}, pattern="openmcp")
+
+    entries = _read_entries(logger)
+    assert len(entries) == 2
+    assert all(e["metadata"]["phase"] == "tools_list" for e in entries)
+    assert all(e["metadata"]["pattern"] == "openmcp" for e in entries)
+
+
+@pytest.mark.asyncio
+async def test_log_tools_call_records_tool_name_and_call_number(tmp_path):
+    logger = ProtocolLogger(log_dir=tmp_path)
+
+    await logger.log_tools_call(
+        {"id": 1},
+        {"id": 1, "result": {}},
+        tool_name="airis-find",
+        call_number=3,
+    )
+
+    entries = _read_entries(logger)
+    assert len(entries) == 2
+    assert all(e["metadata"]["tool_name"] == "airis-find" for e in entries)
+    assert all(e["metadata"]["call_number"] == 3 for e in entries)
+
+
+@pytest.mark.asyncio
+async def test_clear_logs_removes_existing_file(tmp_path):
+    logger = ProtocolLogger(log_dir=tmp_path)
+    await logger.log_message("client→server", {"id": 1})
+    assert logger.log_file.exists()
+
+    logger.clear_logs()
+
+    assert not logger.log_file.exists()
+
+
+def test_clear_logs_is_noop_when_file_absent(tmp_path):
+    logger = ProtocolLogger(log_dir=tmp_path)
+
+    # Should not raise even though no log file has been written yet.
+    logger.clear_logs()
+
+    assert not logger.log_file.exists()


### PR DESCRIPTION
## Summary

#85 lists six core modules that lacked unit tests. Since the issue was filed, `crypto.py`, `registry.py`, and `toolset_catalog.py` gained coverage. This PR closes the remaining genuine gaps — `database.py` and `protocol_logger.py` — and adds a coverage regression ratchet.

## Changes

- **`tests/unit/test_database.py`** — exercises all three import-time mode branches (lite / full / no-SQLAlchemy) via a controlled reload fixture that restores env vars and `sys.modules` on teardown so the rest of the suite is unaffected. `database.py` **0% → 100%**.
- **`tests/unit/test_protocol_logger.py`** — covers log-dir resolution + `/tmp` fallback, the JSONL entry shape written by `log_message`, the `log_initialize` / `log_tools_list` / `log_tools_call` helpers, and `clear_logs`. `protocol_logger.py` **54% → 100%**.
- **`.github/workflows/ci.yml`** — adds `--cov-fail-under=48` to the coverage step.

## Coverage

| Metric | Before | After |
|--------|--------|-------|
| `database.py` | 0% | 100% |
| `protocol_logger.py` | 54% | 100% |
| Total (line) | 47% | 48% |
| Unit tests | 335 | 350 |

## On the 70% target

#85 also asks for a 70% CI gate. Current total coverage is **48%** — a hard 70% gate would fail CI immediately (large modules like `main.py` at 20% and `process_runner.py` at 28% are well below it). Jumping straight to 70% is out of scope for one PR.

Instead this PR adds a **ratchet at the current level (48%)**: coverage can no longer regress, and the number is meant to be raised in every PR that adds tests until it reaches the 70% goal. The CI comment documents this.

`process_runner.py` deep coverage and the climb to 70% remain — so this PR uses `Refs #85`, not `Closes`.

## Verification

Run in an ephemeral `python:3.12-slim` container (host installs are not permitted):

```
350 passed
Required test coverage of 48% reached. Total coverage: 48.19%
```

Refs #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)