### PR TITLE
security: gate /process/* endpoints with explicit auth dependency

### DIFF
--- a/apps/api/src/app/api/endpoints/process_mcp.py
+++ b/apps/api/src/app/api/endpoints/process_mcp.py
@@ -5,13 +5,17 @@ Routes for process-based MCP servers (uvx/npx).
 These endpoints handle direct process communication without Docker Gateway.
 """
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 from typing import Any, Optional
 
+from ...core.auth import verify_api_key
 from ...core.process_manager import get_process_manager
 
-router = APIRouter()
+# Every /process/* route is an admin/mutation endpoint (enable/disable, tool
+# calls, raw JSON-RPC). Gate the whole router behind verify_api_key so it is
+# never served unauthenticated outside local development.
+router = APIRouter(dependencies=[Depends(verify_api_key)])
 
 
 class ToolCallRequest(BaseModel):

--- a/apps/api/src/app/core/auth.py
+++ b/apps/api/src/app/core/auth.py
@@ -1,0 +1,67 @@
+"""API-key authentication dependency for high-impact endpoints.
+
+The ``OptionalBearerAuth`` middleware already gates every request when
+``AIRIS_API_KEY`` is set. ``verify_api_key`` adds a second, explicit layer
+for the ``/process/*`` admin/mutation endpoints (enable/disable, tool calls,
+raw JSON-RPC) so they:
+
+- stay protected even if the middleware is later reordered or removed, and
+- fail closed in any non-development environment that is missing a key,
+  instead of silently serving admin endpoints unauthenticated.
+"""
+from __future__ import annotations
+
+import secrets
+
+from fastapi import HTTPException, Request, status
+
+from .config import settings
+from .logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def verify_api_key(request: Request) -> None:
+    """FastAPI dependency that enforces bearer-token authentication.
+
+    Behaviour:
+
+    - ``AIRIS_API_KEY`` set: a valid ``Authorization: Bearer <key>`` header
+      is required, otherwise ``401``.
+    - ``AIRIS_API_KEY`` unset, ``ENV=development``: open access. This keeps
+      local debugging (e.g. ``curl localhost:9400/process/servers``) working;
+      ``validate_environment()`` already logs a startup warning.
+    - ``AIRIS_API_KEY`` unset, any other ``ENV`` (staging/production): fail
+      closed with ``503``. Admin endpoints must never be exposed
+      unauthenticated outside local development.
+    """
+    api_key = (settings.AIRIS_API_KEY or "").strip()
+
+    if api_key:
+        auth_header = request.headers.get("authorization", "")
+        if auth_header.lower().startswith("bearer "):
+            token = auth_header.split(" ", 1)[1].strip()
+            if secrets.compare_digest(token, api_key):
+                return
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="unauthorized",
+        )
+
+    # No API key configured.
+    if settings.ENV != "development":
+        logger.error(
+            "Refusing unauthenticated access to a protected endpoint: "
+            "AIRIS_API_KEY is not set (ENV=%s).",
+            settings.ENV,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=(
+                "This endpoint is disabled: AIRIS_API_KEY is not configured. "
+                "Set AIRIS_API_KEY to enable authenticated access."
+            ),
+        )
+
+    # Development only: open access for local debugging.
+    return

--- a/apps/api/tests/unit/test_process_endpoints_auth.py
+++ b/apps/api/tests/unit/test_process_endpoints_auth.py
@@ -1,0 +1,128 @@
+"""Authentication tests for the /process/* admin endpoints (issue #97).
+
+The /process/* router exposes high-impact admin/mutation endpoints
+(enable/disable servers, arbitrary tool calls, raw JSON-RPC). These tests
+pin the `verify_api_key` dependency contract and prove the dependency is
+actually wired onto the router.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from starlette.testclient import TestClient
+
+from app.api.endpoints import process_mcp
+from app.core.auth import verify_api_key
+from app.core.config import settings
+
+API_KEY = "test-secret-key-123"
+
+
+class _FakeRequest:
+    """Minimal stand-in exposing only what verify_api_key reads."""
+
+    def __init__(self, headers: dict[str, str] | None = None):
+        self.headers = headers or {}
+
+
+# ── verify_api_key: key configured ───────────────────────────────────────────
+
+
+def test_rejects_request_without_authorization_header(monkeypatch):
+    monkeypatch.setattr(settings, "AIRIS_API_KEY", API_KEY)
+
+    with pytest.raises(HTTPException) as exc:
+        verify_api_key(_FakeRequest())
+
+    assert exc.value.status_code == 401
+
+
+def test_rejects_wrong_token(monkeypatch):
+    monkeypatch.setattr(settings, "AIRIS_API_KEY", API_KEY)
+
+    with pytest.raises(HTTPException) as exc:
+        verify_api_key(_FakeRequest({"authorization": "Bearer wrong-token"}))
+
+    assert exc.value.status_code == 401
+
+
+def test_accepts_correct_token(monkeypatch):
+    monkeypatch.setattr(settings, "AIRIS_API_KEY", API_KEY)
+
+    # Returns None (no exception) when the token matches.
+    assert verify_api_key(_FakeRequest({"authorization": f"Bearer {API_KEY}"})) is None
+
+
+def test_accepts_token_with_case_insensitive_scheme(monkeypatch):
+    monkeypatch.setattr(settings, "AIRIS_API_KEY", API_KEY)
+
+    assert verify_api_key(_FakeRequest({"authorization": f"bearer {API_KEY}"})) is None
+
+
+# ── verify_api_key: no key configured ────────────────────────────────────────
+
+
+def test_open_access_in_development_when_no_key(monkeypatch):
+    monkeypatch.setattr(settings, "AIRIS_API_KEY", None)
+    monkeypatch.setattr(settings, "ENV", "development")
+
+    # Local-dev convenience: open access, no exception.
+    assert verify_api_key(_FakeRequest()) is None
+
+
+def test_fails_closed_in_production_when_no_key(monkeypatch):
+    monkeypatch.setattr(settings, "AIRIS_API_KEY", None)
+    monkeypatch.setattr(settings, "ENV", "production")
+
+    with pytest.raises(HTTPException) as exc:
+        verify_api_key(_FakeRequest())
+
+    assert exc.value.status_code == 503
+
+
+def test_fails_closed_in_staging_when_no_key(monkeypatch):
+    monkeypatch.setattr(settings, "AIRIS_API_KEY", None)
+    monkeypatch.setattr(settings, "ENV", "staging")
+
+    with pytest.raises(HTTPException) as exc:
+        verify_api_key(_FakeRequest())
+
+    assert exc.value.status_code == 503
+
+
+# ── router wiring ────────────────────────────────────────────────────────────
+
+
+def _client() -> TestClient:
+    """Mount the real /process router in isolation (no global middleware)."""
+    app = FastAPI()
+    app.include_router(process_mcp.router, prefix="/process")
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_process_router_requires_auth_when_key_set(monkeypatch):
+    """The router-level dependency rejects unauthenticated requests."""
+    monkeypatch.setattr(settings, "AIRIS_API_KEY", API_KEY)
+
+    response = _client().get("/process/servers")
+
+    assert response.status_code == 401
+
+
+def test_process_router_fails_closed_in_staging_without_key(monkeypatch):
+    """Without a key, /process/* is disabled outside development."""
+    monkeypatch.setattr(settings, "AIRIS_API_KEY", None)
+    monkeypatch.setattr(settings, "ENV", "staging")
+
+    response = _client().get("/process/servers")
+
+    assert response.status_code == 503
+
+
+def test_process_mutation_endpoint_rejects_unauthenticated_caller(monkeypatch):
+    """A disable call (DoS vector) is rejected before reaching the handler."""
+    monkeypatch.setattr(settings, "AIRIS_API_KEY", API_KEY)
+
+    response = _client().post("/process/servers/context7/disable")
+
+    assert response.status_code == 401


### PR DESCRIPTION
## Summary

The `/process/*` router exposes admin/mutation endpoints with **no route-level authorization**:

| Method | Path | Impact |
|--------|------|--------|
| GET | `/process/servers`, `/process/servers/{name}`, `/process/tools` | server/state/info disclosure |
| POST | `/process/servers/{name}/enable` `/disable` | enable/disable any MCP server (DoS) |
| POST | `/process/tools/call`, `/tools/call/{name}`, `/rpc/{name}` | arbitrary tool calls / raw JSON-RPC |

It relies entirely on the global `OptionalBearerAuth` middleware, which **skips auth whenever `AIRIS_API_KEY` is unset**.

## Relationship to #97

#97 was already resolved (COMPLETED) at the **config level**: `validate_environment()` makes a deployment with `ENV=production` **fail startup** when `AIRIS_API_KEY` is missing. That is the accepted primary defence and it is not changed here.

This PR is a **follow-up enhancement**, not a reopening of #97. The config-level fix only covers `ENV=production`; a **staging** deployment (`ENV != production`) missing a key still serves every `/process/*` endpoint unauthenticated. This PR closes that gap and adds defense in depth.

## Change

New `core/auth.py` with a `verify_api_key` FastAPI dependency, applied to the whole `/process/*` router:

```python
router = APIRouter(dependencies=[Depends(verify_api_key)])
```

| Condition | Behaviour |
|-----------|-----------|
| `AIRIS_API_KEY` set | valid `Authorization: Bearer <key>` required, else `401` |
| no key + `ENV=development` | open access (local-dev convenience; startup warning already logged) |
| no key + any other `ENV` (staging/production) | fail closed with `503` |

Defense in depth: the dependency keeps the endpoints protected even if the middleware is reordered or removed.

## Behaviour change

- **Development** (default `ENV`): unchanged — `/process/*` stays open for local debugging.
- **Production**: unchanged in practice — startup already refuses to run without a key.
- **Staging without a key**: `/process/*` now returns `503` instead of serving admin endpoints unauthenticated. Staging should set `AIRIS_API_KEY` (with it set, normal bearer auth applies).

## Tests

`tests/unit/test_process_endpoints_auth.py` (10 tests): `verify_api_key` accept/reject paths, the no-key dev/staging/production branches, and router-wiring tests proving the dependency rejects unauthenticated calls (incl. the `/disable` DoS vector) before reaching the handler.

## Verification

Ephemeral `python:3.12-slim` container: `345 passed` (335 + 10 new), no regressions.

Refs #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)