### PR TITLE
ci: auto-enable auto-merge on PRs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,66 @@
+name: Auto-merge
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  enable-auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge (merge commit)
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+            const nodeId = pr.data.node_id;
+            const mutation = `
+              mutation EnableAutoMerge($id: ID!) {
+                enablePullRequestAutoMerge(input: {
+                  pullRequestId: $id,
+                  mergeMethod: MERGE
+                }) {
+                  pullRequest { number autoMergeRequest { mergeMethod } }
+                }
+              }
+            `;
+            // Retry with exponential backoff.
+            // GitHub rejects with UNPROCESSABLE in two cases:
+            //   1. PR was just opened and checks haven't started yet ("unstable")
+            //   2. All required checks already passed before this mutation ran
+            //      (breaking change introduced ~March 2026)
+            // In case 2 GitHub will auto-merge without this mutation, so we
+            // treat both as non-fatal and retry until the window opens or give up.
+            const maxAttempts = 6;
+            for (let i = 0; i < maxAttempts; i++) {
+              try {
+                await github.graphql(mutation, { id: nodeId });
+                console.log('Auto-merge enabled.');
+                break;
+              } catch (e) {
+                const msg = e.message ?? '';
+                const isUnstable = msg.includes('unstable') ||
+                  (e.errors ?? []).some(err => (err.message ?? '').includes('unstable'));
+                const alreadyEnabled = msg.includes('already enabled') ||
+                  (e.errors ?? []).some(err => (err.message ?? '').includes('already enabled'));
+                if (alreadyEnabled) {
+                  console.log('Auto-merge already enabled, skipping.');
+                  break;
+                }
+                if (isUnstable && i < maxAttempts - 1) {
+                  const delay = Math.min(5000 * 2 ** i, 30000);
+                  console.log(`PR unstable (attempt ${i + 1}/${maxAttempts}), retrying in ${delay}ms…`);
+                  await new Promise(r => setTimeout(r, delay));
+                } else {
+                  throw e;
+                }
+              }
+            }

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -2,65 +2,7 @@ name: Auto-merge
 on:
   pull_request:
     types: [opened, reopened, synchronize]
-
-permissions:
-  pull-requests: write
-  contents: write
-
 jobs:
-  enable-auto-merge:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Enable auto-merge (merge commit)
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const pr = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-            });
-            const nodeId = pr.data.node_id;
-            const mutation = `
-              mutation EnableAutoMerge($id: ID!) {
-                enablePullRequestAutoMerge(input: {
-                  pullRequestId: $id,
-                  mergeMethod: MERGE
-                }) {
-                  pullRequest { number autoMergeRequest { mergeMethod } }
-                }
-              }
-            `;
-            // Retry with exponential backoff.
-            // GitHub rejects with UNPROCESSABLE in two cases:
-            //   1. PR was just opened and checks haven't started yet ("unstable")
-            //   2. All required checks already passed before this mutation ran
-            //      (breaking change introduced ~March 2026)
-            // In case 2 GitHub will auto-merge without this mutation, so we
-            // treat both as non-fatal and retry until the window opens or give up.
-            const maxAttempts = 6;
-            for (let i = 0; i < maxAttempts; i++) {
-              try {
-                await github.graphql(mutation, { id: nodeId });
-                console.log('Auto-merge enabled.');
-                break;
-              } catch (e) {
-                const msg = e.message ?? '';
-                const isUnstable = msg.includes('unstable') ||
-                  (e.errors ?? []).some(err => (err.message ?? '').includes('unstable'));
-                const alreadyEnabled = msg.includes('already enabled') ||
-                  (e.errors ?? []).some(err => (err.message ?? '').includes('already enabled'));
-                if (alreadyEnabled) {
-                  console.log('Auto-merge already enabled, skipping.');
-                  break;
-                }
-                if (isUnstable && i < maxAttempts - 1) {
-                  const delay = Math.min(5000 * 2 ** i, 30000);
-                  console.log(`PR unstable (attempt ${i + 1}/${maxAttempts}), retrying in ${delay}ms…`);
-                  await new Promise(r => setTimeout(r, delay));
-                } else {
-                  throw e;
-                }
-              }
-            }
+  auto-merge:
+    uses: agiletec-inc/.github/.github/workflows/auto-merge.yml@main
+    secrets: inherit


### PR DESCRIPTION
Adds the `auto-merge.yml` workflow (same as airis-studio / airis-workspace / agile-server): on every PR it enables GitHub auto-merge (merge commit) via `actions/github-script`, with exponential-backoff retry for the race windows.

Combined with `allow_auto_merge` and `delete_branch_on_merge` (both already enabled org-wide), PRs merge themselves once CI is green and the remote branch is deleted automatically. Local worktree/branch cleanup is handled by a `git-worktree-sweep` launchd job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)