### PR TITLE
feat: add NotebookLM MCP server and MAGIC_API_KEY passthrough

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -124,6 +124,7 @@ services:
       - CLOUDFLARE_API_TOKEN=${CLOUDFLARE_API_TOKEN:-}
       - FIGMA_API_KEY=${FIGMA_API_KEY:-}
       - GITHUB_TOKEN=${GITHUB_TOKEN:-}
+      - MAGIC_API_KEY=${MAGIC_API_KEY:-}
       - STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY:-}
       - SUPABASE_ACCESS_TOKEN=${SUPABASE_ACCESS_TOKEN:-}
       # Clear OrbStack-injected proxy vars: NO_PROXY contains IPv6 CIDRs that

--- a/mcp-config.json.example
+++ b/mcp-config.json.example
@@ -368,6 +368,30 @@
       "tools_index": [
         {"name": "query", "description": "Execute a SQL query against the PostgreSQL database"}
       ]
+    },
+    "notebooklm": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "notebooklm-mcp@latest"
+      ],
+      "env": {},
+      "enabled": true,
+      "mode": "cold",
+      "tools_index": [
+        {"name": "get_notebooks", "description": "List all NotebookLM notebooks for the current user"},
+        {"name": "create_notebook", "description": "Create a new, empty NotebookLM notebook"},
+        {"name": "chat_notebook", "description": "Chat with a specific NotebookLM notebook, optionally returning source citations"},
+        {"name": "delete_notebook", "description": "Delete a NotebookLM notebook by its ID"},
+        {"name": "get_health", "description": "Inspect server state"},
+        {"name": "setup_auth", "description": "Open a browser window for first-time Google login"},
+        {"name": "re_auth", "description": "Switch to a different Google account or recover from broken auth"},
+        {"name": "cleanup_data", "description": "Two-phase deep cleanup of all server data on disk"},
+        {"name": "add_source", "description": "Ingest a source into a NotebookLM notebook"},
+        {"name": "generate_audio", "description": "Trigger podcast-style Audio Overview generation for a notebook"},
+        {"name": "get_audio_status", "description": "Non-blocking probe for the current Audio Overview state of a notebook"},
+        {"name": "download_audio", "description": "Save the completed Audio Overview to disk as a .m4a file"}
+      ]
     }
   },
   "profiles": {


### PR DESCRIPTION
## Summary
Adds a NotebookLM MCP server to the example config and wires a new API key through the compose environment.

## Changes
- **`mcp-config.json.example`**: adds a `notebooklm` MCP server definition (`npx notebooklm-mcp@latest`, cold mode) with its `tools_index` (notebook CRUD, chat, auth, source ingestion, and Audio Overview generation/download).
- **`compose.yaml`**: passes `MAGIC_API_KEY=${MAGIC_API_KEY:-}` through to the service environment, alongside the existing provider keys.

## Notes
No secrets are committed — only env-variable references (`${MAGIC_API_KEY:-}`) and an empty `env: {}` for the MCP entry.

Co-Authored-By: Oz <oz-agent@warp.dev>