### PR TITLE
fix: self-heal -32602 on the MCP path + surface airis-find inventory

### DIFF
--- a/apps/api/src/app/api/endpoints/mcp_proxy.py
+++ b/apps/api/src/app/api/endpoints/mcp_proxy.py
@@ -49,7 +49,7 @@ from .tool_shaping import (
 )
 from ...core.behavior_compiler import compile_instructions
 from ...core.config import settings
-from ...core.dynamic_mcp import get_dynamic_mcp
+from ...core.dynamic_mcp import get_dynamic_mcp, inject_schema_on_validation_error
 from ...core.logging import get_logger
 from ...core.mcp_config_loader import ServerMode
 from ...core.process_manager import get_process_manager
@@ -858,6 +858,9 @@ async def _proxy_jsonrpc_request(request: Request) -> Response:
                 # airis-workspace) emit it alongside a successful result.
                 server_error = server_response.get("error") if isinstance(server_response, dict) else None
                 if server_error is not None:
+                    # Lazy schema stubs hide params, so a blind call returns
+                    # -32602; re-hydrate it with the full schema for self-heal.
+                    inject_schema_on_validation_error(server_error, tool_name)
                     response_data["error"] = server_error
                 else:
                     response_data["result"] = server_response.get("result")
@@ -892,6 +895,7 @@ async def _proxy_jsonrpc_request(request: Request) -> Response:
                 }
                 inner_error = result.get("error") if isinstance(result, dict) else None
                 if inner_error is not None:
+                    inject_schema_on_validation_error(inner_error, tool_name)
                     response_data["error"] = inner_error
                 else:
                     response_data["result"] = result.get("result")

--- a/apps/api/src/app/api/endpoints/process_mcp.py
+++ b/apps/api/src/app/api/endpoints/process_mcp.py
@@ -159,15 +159,9 @@ async def call_tool(request: ToolCallRequest):
 
     # `"error": null` is "no error" — some servers (e.g. airis-workspace) emit
     # it alongside a successful result.
-    error = response.get("error")
-    if error is not None and error.get("code") in (-32602, -32000):
-        # Validation error: inject full schema so the caller can self-heal on retry.
-        from ...core.dynamic_mcp import get_dynamic_mcp
-        schema_info = get_dynamic_mcp().get_tool_schema(request.name)
-        input_schema = schema_info.get("inputSchema") if schema_info else None
-        if input_schema:
-            error["message"] += f"\n\nFull Schema: {input_schema}"
-            error["hint"] = "Retry with the full schema provided above."
+    # Validation error: inject full schema so the caller can self-heal on retry.
+    from ...core.dynamic_mcp import inject_schema_on_validation_error
+    inject_schema_on_validation_error(response.get("error"), request.name)
 
     return response
 

--- a/apps/api/src/app/core/dynamic_mcp.py
+++ b/apps/api/src/app/core/dynamic_mcp.py
@@ -681,12 +681,23 @@ class DynamicMCP:
         tools = [
             {
                 "name": "airis-find",
-                "description": "Optional fallback search for finding tools.",
+                "description": (
+                    "Discover MCP tools and servers. Call with NO arguments for a "
+                    "full inventory of every connected server (hot/cold/docker, "
+                    "enabled status, tool counts) plus toolsets. Pass "
+                    "server=\"<name>\" to drill into one server's tools, or "
+                    "query=\"keywords\" to search tools across all servers."
+                ),
                 "inputSchema": {
                     "type": "object",
                     "properties": {
                         "query": {
-                            "type": "string"
+                            "type": "string",
+                            "description": "Keywords to search tools across all servers"
+                        },
+                        "server": {
+                            "type": "string",
+                            "description": "Server name to list that server's tools"
                         }
                     }
                 }
@@ -837,3 +848,24 @@ def get_dynamic_mcp() -> DynamicMCP:
     if _dynamic_mcp is None:
         _dynamic_mcp = DynamicMCP()
     return _dynamic_mcp
+
+
+def inject_schema_on_validation_error(
+    error: Optional[dict], tool_name: str
+) -> None:
+    """Re-hydrate an MCP validation error with the tool's full input schema.
+
+    Under SCHEMA_MODE=lazy every tool's inputSchema is stubbed to {"type":
+    "object"} to save context, so a client that calls a tool blind gets a
+    -32602/-32000 back from the backend. Appending the real schema lets the
+    caller self-heal on retry without a separate airis-schema round-trip.
+
+    Mutates `error` in place. No-op for other error codes or unknown tools.
+    """
+    if not error or error.get("code") not in (-32602, -32000):
+        return
+    schema_info = get_dynamic_mcp().get_tool_schema(tool_name)
+    input_schema = schema_info.get("inputSchema") if schema_info else None
+    if input_schema:
+        error["message"] += f"\n\nFull Schema: {input_schema}"
+        error["hint"] = "Retry with the full schema provided above."

--- a/apps/api/tests/unit/test_dynamic_mcp_meta_tools.py
+++ b/apps/api/tests/unit/test_dynamic_mcp_meta_tools.py
@@ -35,6 +35,19 @@ def test_core_meta_tools_shape():
         assert tool["inputSchema"].get("type") == "object"
 
 
+def test_airis_find_advertises_inventory_and_server_drilldown():
+    """airis-find must expose the `server` param and document the bare-call
+    inventory so clients can discover servers/tools without guessing."""
+    mcp = DynamicMCP()
+    find = next(t for t in mcp.get_meta_tools(mode="core") if t["name"] == "airis-find")
+    props = find["inputSchema"]["properties"]
+    assert "query" in props
+    assert "server" in props  # was supported by the handler but hidden from the schema
+    desc = find["description"].lower()
+    assert "no argument" in desc  # bare call → full inventory
+    assert "server" in desc
+
+
 def test_full_meta_tools_adds_optional_tools():
     mcp = DynamicMCP()
     tools = mcp.get_meta_tools(mode="full")

--- a/apps/api/tests/unit/test_mcp_proxy_error_injection.py
+++ b/apps/api/tests/unit/test_mcp_proxy_error_injection.py
@@ -1,0 +1,149 @@
+"""
+Regression test for the -32602 error-injection path on the MCP Streamable HTTP
+proxy (`_proxy_jsonrpc_request`).
+
+The REST endpoint `/process/tools/call` already re-hydrates -32602/-32000 errors
+with the tool's full input schema (see test_process_mcp_error_injection.py). But
+real MCP clients (Claude Code, Codex) never hit that REST path — they POST
+`tools/call` to `/mcp/`, which routes through `_proxy_jsonrpc_request`. That path
+returned the backend validation error verbatim, so the lazy-schema "self-heal on
+retry" contract silently did nothing for actual clients.
+
+These tests pin the contract on the Streamable HTTP (no-sessionid) path.
+"""
+import json
+
+import pytest
+
+from app.api.endpoints import mcp_proxy
+from app.core.dynamic_mcp import DynamicMCP, ToolInfo
+from app.core.process_manager import ProcessManager
+
+RESOLVE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "query": {"type": "string"},
+        "libraryName": {"type": "string"},
+    },
+    "required": ["query", "libraryName"],
+}
+
+
+class FakeRequest:
+    """Minimal Starlette-Request stand-in for _proxy_jsonrpc_request."""
+
+    def __init__(self, payload: dict):
+        self._body = json.dumps(payload).encode()
+        # no sessionid → Streamable HTTP branch
+        self.query_params: dict = {}
+
+    async def body(self) -> bytes:
+        return self._body
+
+
+@pytest.fixture
+def wired(monkeypatch):
+    """Stub ProcessManager + DynamicMCP singletons used by mcp_proxy."""
+    pm = ProcessManager()
+    pm._initialized = True
+    pm._tool_to_server = {"resolve-library-id": "context7"}
+    monkeypatch.setattr(
+        "app.api.endpoints.mcp_proxy.get_process_manager", lambda: pm
+    )
+
+    dmcp = DynamicMCP()
+    dmcp._tools["resolve-library-id"] = ToolInfo(
+        name="resolve-library-id",
+        server="context7",
+        description="Resolve a library name to a Context7 ID",
+        input_schema=RESOLVE_SCHEMA,
+        source="process",
+    )
+    # mcp_proxy.get_dynamic_mcp is used on the auto-discovery path; the shared
+    # inject_schema_on_validation_error helper reads app.core.dynamic_mcp's.
+    monkeypatch.setattr(
+        "app.api.endpoints.mcp_proxy.get_dynamic_mcp", lambda: dmcp
+    )
+    monkeypatch.setattr(
+        "app.core.dynamic_mcp.get_dynamic_mcp", lambda: dmcp
+    )
+    return pm
+
+
+def _tools_call(name: str, arguments: dict) -> dict:
+    return {
+        "jsonrpc": "2.0",
+        "id": 7,
+        "method": "tools/call",
+        "params": {"name": name, "arguments": arguments},
+    }
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_injects_schema_on_32602(wired, monkeypatch):
+    pm = wired
+
+    async def fake_call_tool(name, arguments):
+        return {
+            "jsonrpc": "2.0",
+            "id": 7,
+            "error": {"code": -32602, "message": "Invalid arguments for tool"},
+        }
+
+    monkeypatch.setattr(pm, "call_tool", fake_call_tool)
+
+    resp = await mcp_proxy._proxy_jsonrpc_request(
+        FakeRequest(_tools_call("resolve-library-id", {"query": "fastapi"}))
+    )
+
+    body = json.loads(resp.body)
+    assert body["error"]["code"] == -32602
+    # The full schema must be injected so the caller can self-heal on retry.
+    assert "Full Schema" in body["error"]["message"]
+    assert "libraryName" in body["error"]["message"]
+    assert body["error"]["hint"].startswith("Retry")
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_passes_through_non_validation_error(wired, monkeypatch):
+    pm = wired
+
+    async def fake_call_tool(name, arguments):
+        return {
+            "jsonrpc": "2.0",
+            "id": 7,
+            "error": {"code": -32601, "message": "Method not found"},
+        }
+
+    monkeypatch.setattr(pm, "call_tool", fake_call_tool)
+
+    resp = await mcp_proxy._proxy_jsonrpc_request(
+        FakeRequest(_tools_call("resolve-library-id", {}))
+    )
+
+    body = json.loads(resp.body)
+    assert body["error"]["code"] == -32601
+    assert "Full Schema" not in body["error"]["message"]
+    assert "hint" not in body["error"]
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_success_is_untouched(wired, monkeypatch):
+    pm = wired
+
+    async def fake_call_tool(name, arguments):
+        return {
+            "jsonrpc": "2.0",
+            "id": 7,
+            "result": {"content": [{"type": "text", "text": "ok"}]},
+        }
+
+    monkeypatch.setattr(pm, "call_tool", fake_call_tool)
+
+    resp = await mcp_proxy._proxy_jsonrpc_request(
+        FakeRequest(_tools_call("resolve-library-id", {"query": "x", "libraryName": "x"}))
+    )
+
+    body = json.loads(resp.body)
+    assert "error" not in body
+    assert body["result"]["content"][0]["text"] == "ok"


### PR DESCRIPTION
## What

Under `SCHEMA_MODE=lazy` (the default) every tool's `inputSchema` is stubbed to `{"type":"object"}` to save context tokens. The recovery mechanism — re-hydrating `-32602`/`-32000` validation errors with the tool's **full schema** so a caller can self-heal on retry — only existed in the REST `/process/tools/call` path.

Real MCP clients (Claude Code, Codex) POST `tools/call` to `/mcp/`, which routes through `_proxy_jsonrpc_request()` and returned the backend validation error **verbatim**. So the self-heal contract never fired for actual clients: a blind tool call got a bare `-32602` with no schema, forcing trial-and-error to discover required args.

This was reproduced live — calling `resolve-library-id` via the gateway returned `Invalid arguments ... query: expected string, received undefined` with no schema attached.

## Changes

- Extract `inject_schema_on_validation_error()` into `dynamic_mcp.py`.
- Call it on **both** `tools/call` branches in `mcp_proxy.py` (ProcessManager route + auto-discovery route).
- Replace the duplicated REST-path logic in `process_mcp.py` with the shared helper.
- `airis-find`: rewrite the description to advertise the **bare-call inventory** (no args → full server/tool listing) and expose the previously **hidden `server` drill-down param** (the handler already read it; it was just absent from the schema).

## Verification (test-first)

- New `test_mcp_proxy_error_injection.py` pins the `/mcp/` contract — reproduced the gap first (asserting `"Full Schema"` failed pre-fix), then green after the fix.
- Extended `test_dynamic_mcp_meta_tools.py` for the `airis-find` schema/description.
- Full unit suite: **372 passed**.

## Notes

- Not a config issue: `SCHEMA_MODE` defaults to `lazy` and is not overridden in compose/.env. The stubbing worked as configured; the injection code simply did not exist on the MCP path.
- Behavior for non-validation errors (`-32601` etc.) and successful calls is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)