### PR TITLE
fix(catalog): pin mindbase EMBEDDING_MODEL to a literal value

### DIFF
--- a/catalogs/airis-catalog.yaml
+++ b/catalogs/airis-catalog.yaml
@@ -39,7 +39,7 @@ registry:
       - name: OLLAMA_URL
         value: '{{mindbase_settings.ollama_url|default:"http://host.docker.internal:11434"}}'
       - name: EMBEDDING_MODEL
-        value: '{{mindbase_settings.embedding_model|default:"nomic-embed-text"}}'
+        value: "qwen3-embedding:0.6b"
     allowHosts:
       - "*"
 


### PR DESCRIPTION
## What

`catalogs/airis-catalog.yaml` set the mindbase MCP server's `EMBEDDING_MODEL` via a `{{mindbase_settings.embedding_model|default:"nomic-embed-text"}}` filter template. The pinned `docker/mcp-gateway` binary **silently drops** any env entry whose value uses a `|default:` filter, so the override never reached the spawned container — the mindbase image's baked-in `ENV EMBEDDING_MODEL=nomic-embed-text` leaked through instead.

The trap: when the template default equals the image ENV default, it looks like it works. Here we actually want `qwen3-embedding:0.6b`, which differs from the image default, so the bug became visible.

## Change

```diff
 - name: EMBEDDING_MODEL
-  value: '{{mindbase_settings.embedding_model|default:"nomic-embed-text"}}'
+  value: "qwen3-embedding:0.6b"
```

`OLLAMA_URL` / `DATABASE_URL` intentionally keep their templates: their image ENV defaults already match the desired runtime values, so only `EMBEDDING_MODEL` needs to deviate to a literal.

## Verification

- `docker inspect <mindbase-image> --format '{{.Config.Env}}'` to confirm the baked default, vs. the spawned container's effective `EMBEDDING_MODEL`.
- Catalog-level env (not `--additional-config`) — same filter path was confirmed non-functional for templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)