### PR TITLE
fix(ci): correct Release version sort (v2.1.0 not v1.34.1) + idempotent bump PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,11 @@ jobs:
       - name: Determine version bump
         id: version
         run: |
-          # Get highest version tag (sort semantically)
-          LATEST_TAG=$(git tag -l 'v*' | sort -t. -k1,1n -k2,2n -k3,3n | tail -1)
+          # Get highest version tag. `sort -V` understands the leading "v" and
+          # compares major.minor.patch correctly. The previous
+          # `sort -t. -k1,1n` treated the "v"-prefixed major field as 0, so it
+          # ignored major entirely and picked v1.34.1 over v2.1.0.
+          LATEST_TAG=$(git tag -l 'v*' | sort -V | tail -1)
           if [ -z "$LATEST_TAG" ]; then
             LATEST_TAG="v0.0.0"
           fi
@@ -98,16 +101,24 @@ jobs:
             fi
           done
 
-          git checkout -b "$BRANCH"
+          # Idempotent on re-run: reset the branch (-B) and force-push so a
+          # stale remote branch from an earlier run can't cause a
+          # non-fast-forward rejection. Only open a PR if one isn't already
+          # tracking the branch (a re-run just updates it via the force-push).
+          git checkout -B "$BRANCH"
           git add VERSION apps/*/package.json apps/*/pyproject.toml
           git commit -m "chore: bump version to $NEW_VERSION [skip ci]"
-          git push origin "$BRANCH"
+          git push --force-with-lease origin "$BRANCH"
 
-          gh pr create \
-            --base main \
-            --head "$BRANCH" \
-            --title "chore: bump version to $NEW_VERSION" \
-            --body "Automated version bump to ${NEW_VERSION}."
+          if [ -n "$(gh pr list --head "$BRANCH" --state open --json number --jq '.[].number')" ]; then
+            echo "ℹ️  PR for $BRANCH already open; updated it via force-push."
+          else
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "chore: bump version to $NEW_VERSION" \
+              --body "Automated version bump to ${NEW_VERSION}."
+          fi
 
       - name: Create GitHub Release
         if: steps.check_tag.outputs.exists == 'false'


### PR DESCRIPTION
## Symptom

The **Release** workflow has failed on every push to `main` since 2026-05-10 (Docker Publish succeeds; Release does not). The `v2.x` tags were created manually because this workflow was effectively bypassed.

## Root cause

### 1. Tag sort ignores the major version
```bash
LATEST_TAG=$(git tag -l 'v*' | sort -t. -k1,1n -k2,2n -k3,3n | tail -1)
```
`-k1,1n` numeric-sorts the first field, but it is `v1` / `v2` — the leading `v` makes every major collapse to `0`, so the sort orders by **minor** and returns the wrong tag:

| sort | result |
|------|--------|
| `sort -t. -k1,1n -k2,2n -k3,3n \| tail -1` | `v1.34.1` ❌ |
| `sort -V \| tail -1` | `v2.1.0` ✅ |

So `CURRENT_VERSION` became `1.34.1` (real latest is `2.1.0`) → `NEW_VERSION=1.35.0`, a downgrade.

### 2. Stale branch collision (the actual failing step)
With `NEW_VERSION` pinned at `1.35.0`, every run tried to push the same branch `chore/bump-version-1.35.0`. A leftover remote branch from 2026-05-10 made `git push origin "$BRANCH"` (no force) fail:
```
! [rejected] chore/bump-version-1.35.0 (non-fast-forward)
```

## Fix

1. Compute `LATEST_TAG` with `sort -V` — correctly selects `v2.1.0`, so the next bump is `2.2.0`.
2. Harden the *Create version bump PR* step against re-runs:
   - `git checkout -B` (reset branch) + `git push --force-with-lease` so a stale remote branch can't cause a non-fast-forward rejection.
   - open a PR only if one isn't already tracking the branch (a re-run just updates it via the force-push), avoiding `gh pr create` "already exists" failures.

## Verification

- `sort -V` selection reproduced locally against the real tag list (`v1.32.0 … v2.1.0`) → `v2.1.0`.
- YAML parses cleanly; `if/else/fi` balanced.

## Follow-up (not in this PR)

- Stale remote branch `chore/bump-version-1.35.0` (commit `7b1a6db0`) can be deleted: `git push origin --delete chore/bump-version-1.35.0`. Harmless once the sort is fixed (that name is never recomputed), but it's litter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)