### PR TITLE
fix(ci): open release/bump PRs via a GitHub App token (most-secure official pattern)

### DIFF
--- a/.github/workflows/bump-airis-version.yml
+++ b/.github/workflows/bump-airis-version.yml
@@ -3,9 +3,10 @@ name: Bump AIRIS_VERSION
 on:
   workflow_dispatch:
 
+# Privileged push/PR uses the App token below; the ambient GITHUB_TOKEN only
+# needs read access (checkout + cross-repo public release lookup).
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   bump:
@@ -13,9 +14,36 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Short-lived, least-privilege App token — GITHUB_TOKEN cannot open PRs
+      # (org-wide "Actions can create/approve PRs" is disabled by default).
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RELEASE_BUMPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_BUMPER_APP_PRIVATE_KEY }}
+          owner: agiletec-inc
+          repositories: airis-mcp-gateway
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Resolve App bot identity
+        id: bot
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          SLUG="${{ steps.app-token.outputs.app-slug }}"
+          USER_ID=$(gh api "/users/${SLUG}[bot]" --jq .id)
+          {
+            echo "name=${SLUG}[bot]"
+            echo "email=${USER_ID}+${SLUG}[bot]@users.noreply.github.com"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Check latest airis-workspace version
         id: ver
         env:
+          # Cross-repo public read — the App token is scoped to this repo only,
+          # so use the ambient token here.
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           LATEST=$(gh api repos/agiletec-inc/airis-workspace/releases/latest --jq '.tag_name | ltrimstr("v")')
@@ -38,7 +66,9 @@ jobs:
         id: pr
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
+          committer: "${{ steps.bot.outputs.name }} <${{ steps.bot.outputs.email }}>"
+          author: "${{ steps.bot.outputs.name }} <${{ steps.bot.outputs.email }}>"
           branch: chore/bump-airis-${{ steps.ver.outputs.latest }}
           commit-message: "chore: bump AIRIS_VERSION to ${{ steps.ver.outputs.latest }}"
           title: "chore: bump AIRIS_VERSION to ${{ steps.ver.outputs.latest }}"
@@ -51,5 +81,5 @@ jobs:
       - name: Auto-merge pull request
         if: steps.pr.outputs.pull-request-number
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: gh pr merge ${{ steps.pr.outputs.pull-request-number }} --merge --auto

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,14 +9,46 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    # All privileged actions use the App token minted below; the ambient
+    # GITHUB_TOKEN only needs read access.
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     steps:
+      # Mint a short-lived (1h), least-privilege GitHub App installation token.
+      # GITHUB_TOKEN cannot open PRs — "Allow GitHub Actions to create and
+      # approve pull requests" is disabled org-wide as the secure default — and
+      # GitHub recommends an App token over a long-lived PAT for this.
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RELEASE_BUMPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_BUMPER_APP_PRIVATE_KEY }}
+          owner: agiletec-inc
+          repositories: airis-mcp-gateway
+          # Least-privilege: only what the bump PR + release creation need.
+          permission-contents: write
+          permission-pull-requests: write
+
+      # Resolve the bot's numeric user-id so the bump commit is attributed to a
+      # verified <id>+<slug>[bot]@users.noreply.github.com author.
+      - name: Resolve App bot identity
+        id: bot
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          SLUG="${{ steps.app-token.outputs.app-slug }}"
+          USER_ID=$(gh api "/users/${SLUG}[bot]" --jq .id)
+          {
+            echo "name=${SLUG}[bot]"
+            echo "email=${USER_ID}+${SLUG}[bot]@users.noreply.github.com"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Determine version bump
         id: version
@@ -79,13 +111,13 @@ jobs:
         # all steps because the tag already exists at that point.
         if: steps.check_tag.outputs.exists == 'false'
         env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           NEW_VERSION=${{steps.version.outputs.version}}
           BRANCH="chore/bump-version-${NEW_VERSION}"
 
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "${{ steps.bot.outputs.name }}"
+          git config --global user.email "${{ steps.bot.outputs.email }}"
 
           echo "$NEW_VERSION" > VERSION
           for f in apps/*/package.json; do
@@ -123,7 +155,7 @@ jobs:
       - name: Create GitHub Release
         if: steps.check_tag.outputs.exists == 'false'
         env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           VERSION=${{steps.version.outputs.version}}
 


### PR DESCRIPTION
## Problem

After #170 fixed the version sort, the **Release** workflow still failed — now at *Create version bump PR*:

```
pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve pull requests (createPullRequest)
```

`GITHUB_TOKEN` cannot open PRs because **"Allow GitHub Actions to create and approve pull requests" is disabled at both org and repo level** (`can_approve_pull_request_reviews: false`) — the secure default that prevents Actions from self-approving/merging. `bump-airis-version.yml` carried the same latent defect (`peter-evans/create-pull-request` + `GITHUB_TOKEN`).

## Approach — researched against official docs

GitHub's documented, most-secure alternative is a **short-lived GitHub App installation token** (least-privilege, 1h, auto-revoked) rather than a long-lived PAT, and rather than weakening the org-wide self-approval setting. This mirrors the pattern already used across the org (`airis-workspace`, `cmd-ime`, `agiletec`).

Both workflows now:
- mint a token with `actions/create-github-app-token@v3`, scoped to `owner: agiletec-inc`, `repositories: airis-mcp-gateway`, with only `permission-contents: write` + `permission-pull-requests: write` (auto-revoked in the action's post step);
- resolve the App bot identity so the bump commit has a verified `<id>+<slug>[bot]@users.noreply.github.com` author;
- use the App token for checkout/push/`gh`, and drop the ambient `GITHUB_TOKEN` to `contents: read`.
- `bump-airis-version.yml` keeps the **cross-repo** airis-workspace release lookup on the ambient `GITHUB_TOKEN` (public read) — the App token is scoped to this repo only.

## ⚠️ Required before this works (org admin)

Provision the App and credentials, otherwise the *Generate App token* step fails:

1. Create (or reuse) a GitHub App with **Repository permissions: Contents = Read and write, Pull requests = Read and write**.
2. Install it on `agiletec-inc/airis-mcp-gateway`.
3. Add **org variable** `RELEASE_BUMPER_APP_CLIENT_ID` (App Client ID — public) and **org secret** `RELEASE_BUMPER_APP_PRIVATE_KEY` (the App private key).

If you'd rather reuse an existing App, swap those two names for an App that is installed here with both permissions (e.g. a Contents+PR-capable bumper App). Note `AUTOMERGE_APP` is PR-only in current use and may lack `contents: write`.

## Verification

- Both workflows parse as valid YAML; token wiring audited (all writes via the App token; only the intentional cross-repo read uses `GITHUB_TOKEN`).
- `@v3` matches the current action major and the org's existing usage.
- Full release path (sort → bump PR → release) is exercised the next time `main` advances once the credentials exist.

## Notes

- Orphan branch `chore/bump-version-2.2.0` from the earlier failed run is harmless — the idempotent step (`checkout -B` + `--force-with-lease` from #170) will update it and open its PR on the next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)