### PR TITLE
fix(ci): use existing image-bumper App for release/bump tokens (no new App)

### DIFF
--- a/.github/workflows/bump-airis-version.yml
+++ b/.github/workflows/bump-airis-version.yml
@@ -20,8 +20,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ vars.RELEASE_BUMPER_APP_CLIENT_ID }}
-          private-key: ${{ secrets.RELEASE_BUMPER_APP_PRIVATE_KEY }}
+          client-id: ${{ vars.IMAGE_BUMPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.IMAGE_BUMPER_APP_PRIVATE_KEY }}
           owner: agiletec-inc
           repositories: airis-mcp-gateway
           permission-contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ vars.RELEASE_BUMPER_APP_CLIENT_ID }}
-          private-key: ${{ secrets.RELEASE_BUMPER_APP_PRIVATE_KEY }}
+          client-id: ${{ vars.IMAGE_BUMPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.IMAGE_BUMPER_APP_PRIVATE_KEY }}
           owner: agiletec-inc
           repositories: airis-mcp-gateway
           # Least-privilege: only what the bump PR + release creation need.


### PR DESCRIPTION
Follow-up to #171. Instead of provisioning a brand-new `RELEASE_BUMPER` App, reuse the existing **`agiletec-image-bumper`** App, which already has exactly the permissions the bump flow needs.

## Why image-bumper

Verified via the org installations API:

| App | contents | pull_requests |
|-----|----------|---------------|
| `agiletec-automerge` | ❌ (PR-only) | ✅ write |
| **`agiletec-image-bumper`** | ✅ **write** | ✅ **write** |

The version bump must **push a branch** (contents:write) **and open a PR** (pull-requests:write). `image-bumper` covers both; `automerge` cannot push.

## Change

Both `release.yml` and `bump-airis-version.yml` now reference `IMAGE_BUMPER_APP_CLIENT_ID` / `IMAGE_BUMPER_APP_PRIVATE_KEY` (these org var/secret already exist). The token request stays scoped to `repositories: airis-mcp-gateway` with least-privilege `permission-contents: write` + `permission-pull-requests: write`.

## ⚠️ One admin step

Add **`agiletec-inc/airis-mcp-gateway`** to the `agiletec-image-bumper` App's installation (repository access). No new secret/variable needed — `IMAGE_BUMPER_APP_*` already exist at org level.

## Cleanup note (separate)

`agiletec-automerge` was given `contents: write` during setup but doesn't need it (it only runs `gh pr merge --auto`). Recommend reverting it to `pull_requests: write` + `metadata: read` for least privilege.

## Verification

- Both workflows parse as valid YAML; no `RELEASE_BUMPER_*` references remain.
- After merge + the install step, the next push to `main` exercises the full path (sort → App token → bump PR → release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)