### PR TITLE
chore(ci): harden ci.yml — SHA-pin third-party actions + least-privilege token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,12 @@ on:
     branches:
       - main
 
+# Least privilege: every job here is read-only (checkout, tests, scans,
+# coverage upload). Set the default GITHUB_TOKEN to read so no job silently
+# gains write.
+permissions:
+  contents: read
+
 jobs:
   # airis-mcp-gateway is a PUBLIC repo — every job must run on a GitHub-hosted
   # runner. This guard runs unconditionally (no path filter) so it can serve as
@@ -28,7 +34,7 @@ jobs:
       shell: ${{ steps.filter.outputs.shell }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         id: filter
         with:
           filters: |
@@ -69,7 +75,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Install dependencies
         run: |
@@ -85,7 +91,7 @@ jobs:
           python -m pytest tests/unit -v --tb=short --cov=src --cov-report=xml --cov-report=term-missing --cov-fail-under=48
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
         with:
           files: apps/api/coverage.xml
           flags: python
@@ -111,7 +117,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
Applies the GitHub Actions hardening best practices flagged in the workflow audit.

## Changes

1. **SHA-pin third-party actions** (mutable tags can be repointed; full commit SHAs are immutable). Version retained in a trailing comment:
   - `dorny/paths-filter` → `fbd0ab8f…` # v4
   - `astral-sh/setup-uv` → `37802adc…` # v7
   - `codecov/codecov-action` → `fb8b3582…` # v6
   - `pnpm/action-setup` → `b906affc…` # v4
2. **Top-level `permissions: contents: read`** — every job in this workflow is read-only (checkout, tests, scans, coverage upload), so the default `GITHUB_TOKEN` shouldn't carry write.

`actions/*` (first-party, GitHub-owned) are left on major tags.

## Verification

- YAML parses; SHAs resolved from each action's current major tag via the GitHub API; no third-party `uses:` remains on a tag.

## Note

`docker-publish.yml` also uses third-party `docker/*` actions on tags — can be pinned the same way in a follow-up if desired (kept out of this PR to stay focused).

🤖 Generated with [Claude Code](https://claude.com/claude-code)