### PR TITLE
docs: document VERSION-file-driven release process

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,3 +150,5 @@ Use the `playwright-cli` skill (host Chrome, headless). Flow: `playwright-cli op
 Path-based triggers:
 - `apps/api/**` → Python tests (pytest)
 - `apps/gateway-control/**` or `apps/airis-commands/**` → TypeScript build
+
+Releasing: `VERSION` is the source of truth. Bump it (run `task version:sync` to propagate to the package manifests) in a normal PR; on merge `release.yml` tags the commit `v<VERSION>` and publishes a GitHub Release (once per version). The release workflow only reads `VERSION` and creates the tag/Release with `GITHUB_TOKEN` — it never opens a PR, so no GitHub App is involved.


### PR DESCRIPTION
One-line addition to CLAUDE.md's CI/CD section recording the release process after #173/#174/#175:

- `VERSION` is the source of truth; bump it (+ `task version:sync`) in a normal PR.
- `release.yml` tags `v<VERSION>` + publishes the Release with `GITHUB_TOKEN`, once per version — never opens a PR, no GitHub App.

Keeps future contributors (and agents) from reaching for the old auto-bump-PR / App-token approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)