### PR TITLE
feat(mindbase): make conversation/memory tools discoverable via airis-find

### DIFF
--- a/apps/api/src/app/core/dynamic_mcp.py
+++ b/apps/api/src/app/core/dynamic_mcp.py
@@ -435,6 +435,13 @@ class DynamicMCP:
             # Deduplicate while preserving order
             query_variants = list(dict.fromkeys(query_variants))
 
+        # Per-word keyword set for matching cached tools against TOOL_CATALOG.
+        # Substring matching on the full query misses keyword-style queries
+        # (e.g. "search past conversations" never substrings "conversation_search"),
+        # so cached tools also match when their catalog keywords intersect.
+        from .tool_suggester import TOOL_CATALOG, _extract_keywords
+        query_keywords = set(_extract_keywords(query)) if query_lower else set()
+
         # Search servers
         for name, info in self._servers.items():
             if server and name != server:
@@ -475,10 +482,13 @@ class DynamicMCP:
                 name_lower = name.lower()
                 desc_lower = info.description.lower()
                 server_lower = info.server.lower()
-                if not any(
+                substring_match = any(
                     v in name_lower or v in desc_lower or v in server_lower
                     for v in query_variants
-                ):
+                )
+                catalog_keywords = TOOL_CATALOG.get(info.server, {}).get(name, [])
+                keyword_match = bool(query_keywords & set(catalog_keywords))
+                if not (substring_match or keyword_match):
                     continue
 
             matched_tools.append({

--- a/apps/api/src/app/core/tool_suggester.py
+++ b/apps/api/src/app/core/tool_suggester.py
@@ -83,6 +83,20 @@ class SuggestToolResponse:
 # Known MCP tool categories with common keywords
 # This serves as a fallback when we can't fetch from DynamicMCP
 TOOL_CATALOG: Dict[str, Dict[str, List[str]]] = {
+    "mindbase": {
+        "conversation_search": ["conversation", "conversations", "search", "past", "history", "semantic", "recall", "chat", "transcript", "memory", "find", "previous"],
+        "conversation_hybrid_search": ["conversation", "search", "hybrid", "keyword", "semantic", "history", "past"],
+        "conversation_save": ["conversation", "save", "store", "ingest", "transcript"],
+        "conversation_get": ["conversation", "get", "retrieve", "list", "fetch"],
+        "conversation_timeline": ["conversation", "timeline", "chronological", "history", "when"],
+        "conversation_topics": ["conversation", "topics", "themes", "group"],
+        "memory_search": ["memory", "search", "recall", "remember", "knowledge", "semantic"],
+        "memory_write": ["memory", "write", "save", "store", "remember", "note"],
+        "memory_read": ["memory", "read", "get", "recall"],
+        "memory_list": ["memory", "list", "show"],
+        "content_generate": ["content", "article", "generate", "draft", "blog", "note", "zenn", "qiita", "write"],
+        "content_publish": ["content", "publish", "post", "platform"],
+    },
     "memory": {
         "create_entities": ["memory", "entity", "create", "store", "save", "knowledge"],
         "search_nodes": ["memory", "search", "find", "query", "retrieve", "knowledge"],

--- a/mcp-config.json.example
+++ b/mcp-config.json.example
@@ -133,7 +133,26 @@
       "env": {},
       "enabled": false,
       "mode": "cold",
-      "_comment": "Managed by Docker MCP Gateway via airis-catalog.yaml"
+      "_comment": "Managed by Docker MCP Gateway via airis-catalog.yaml",
+      "tools_index": [
+        {"name": "conversation_search", "description": "Semantic search across past LLM conversations (Claude Code, ChatGPT, Cursor, etc.) using pgvector cosine similarity with recency ranking"},
+        {"name": "conversation_hybrid_search", "description": "Hybrid search over conversations combining keyword (full-text), semantic (vector) and recency with configurable weights"},
+        {"name": "conversation_save", "description": "Save a conversation with automatic embedding generation for semantic search"},
+        {"name": "conversation_get", "description": "Retrieve conversations with filtering and pagination"},
+        {"name": "conversation_timeline", "description": "Chronological timeline of conversations across all sources"},
+        {"name": "conversation_topics", "description": "Topic groups spanning multiple conversation sources and time periods"},
+        {"name": "conversation_delete", "description": "Delete a conversation by ID"},
+        {"name": "memory_search", "description": "Semantic search across long-term memories using pgvector similarity"},
+        {"name": "memory_write", "description": "Write a memory to markdown file and database for future reference"},
+        {"name": "memory_read", "description": "Read a memory by name from markdown file or database"},
+        {"name": "memory_list", "description": "List all available memories with optional filtering"},
+        {"name": "memory_delete", "description": "Delete a memory from markdown file and database"},
+        {"name": "session_start", "description": "Start or resume a session (sets current conversation context)"},
+        {"name": "session_create", "description": "Create a new session for organizing conversations"},
+        {"name": "session_list", "description": "List recent sessions with metadata"},
+        {"name": "content_generate", "description": "Generate platform-tailored article drafts (note/Zenn/Qiita) from stored conversations"},
+        {"name": "content_publish", "description": "Publish generated content to a target platform"}
+      ]
     },
     "airis-mcp-gateway-control": {
       "command": "node",


### PR DESCRIPTION
## What

Make the mindbase MCP server's tools (`conversation_search`, `conversation_hybrid_search`, `memory_search`, `conversation_timeline`, …) discoverable through `airis-find` and routable when called.

## Why

mindbase was registered but **none of its tools surfaced via `airis-find`**, so they were effectively invisible to agents:

1. mindbase was absent from `TOOL_CATALOG` (the keyword index `airis-find` searches).
2. The mindbase entry in `mcp-config.json` had no `tools_index` (used to auto-enable COLD servers on first native tool call).
3. A latent `find()` bug: the TOOL_CATALOG keyword fallback only runs `if not matched_tools` and **skips tools already cached in `self._tools`**. Once a COLD server's `tools_index` is cached, its tools land in `self._tools`, but the primary search only substring-matches the full query against name/description — so a keyword query like `"search past conversations"` never matched `conversation_search`, and it fell through both paths.

## Changes

- **`tool_suggester.py`** — add a `"mindbase"` entry to `TOOL_CATALOG` with keywords for `conversation_*` / `memory_*` / `content_*` tools.
- **`dynamic_mcp.py`** — in `find()`, also match cached tools against their `TOOL_CATALOG` keywords (not just substring), so keyword queries surface cached COLD-server tools. General fix, not mindbase-specific.
- **`mcp-config.json.example`** — add `tools_index` to the mindbase server for auto-discovery/routing.

## Verification

Rebuilt the gateway image and confirmed end-to-end on a live gateway:

```
airis-find "search my past conversations history"
→ mindbase:conversation_search, mindbase:conversation_hybrid_search,
  mindbase:memory_search, mindbase:conversation_timeline, …
airis-schema conversation_search → full input schema returned
```

(Backing data: 191 Claude Code conversations populated in the mindbase DB; semantic search verified against the same embedding path — qwen3-embedding:0.6b, 1024-dim.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)