### PR TITLE
ci: drop broken App-token auto-merge workflow (use native auto-merge)

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,8 +1,0 @@
-name: Auto-merge
-on:
-  pull_request:
-    types: [opened, reopened, synchronize]
-jobs:
-  auto-merge:
-    uses: agiletec-inc/.github/.github/workflows/auto-merge.yml@main
-    secrets: inherit


### PR DESCRIPTION
ci: drop broken App-token auto-merge workflow (use native auto-merge)

The enable-auto-merge workflow minted an agiletec-automerge App token to call
enablePullRequestAutoMerge, which fails with 'Resource not accessible by
integration'. Native GitHub auto-merge (allow_auto_merge is already enabled on
this repo) replaces it — enable per-PR with 'gh pr merge --auto'. No App needed.