### PR TITLE
chore(funding): drop redundant per-repo FUNDING.yml, inherit org SSoT

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,0 @@
-# Funding options for AIRIS MCP Gateway
-# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
-
-github: [agiletec-inc]


### PR DESCRIPTION
Part of the org-wide funding cleanup: single Source of Truth at `agiletec-inc/.github/FUNDING.yml`.

## Change
- Delete `.github/FUNDING.yml` (`github: [agiletec-inc]`). It duplicated the org default community health file. With it gone, the repo inherits the org SSoT — the Sponsor button still resolves to `agiletec-inc`, but there's nothing to keep in sync per-repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)