### PR TITLE
chore: follow airis-workspace 4.0.0 binary rename (do not merge before 4.0.0 release)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
 # missing release artifact fails loudly instead of silently dragging in a
 # Rust toolchain at image-build time. cargo-binstall is removed after use
 # to keep the runtime image lean.
-ARG AIRIS_VERSION=3.6.7
+ARG AIRIS_VERSION=4.0.0
 ARG BINSTALL_VERSION=1.18.1
 RUN set -eux; \
     curl -fsSL "https://github.com/cargo-bins/cargo-binstall/releases/download/v${BINSTALL_VERSION}/cargo-binstall-$(uname -m)-unknown-linux-musl.tgz" \
@@ -86,7 +86,7 @@ RUN set -eux; \
         --root /usr/local \
         airis-workspace --version "${AIRIS_VERSION}"; \
     rm /usr/local/bin/cargo-binstall; \
-    airis --version
+    airis-workspace --version
 
 # Install uv (for uvx MCP servers)
 RUN --mount=type=cache,target=/root/.cache/pip \

--- a/mcp-config.json.example
+++ b/mcp-config.json.example
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "airis-workspace": {
-      "command": "airis",
+      "command": "airis-workspace",
       "args": ["mcp"],
       "env": {},
       "enabled": true,


### PR DESCRIPTION
Tracks the `airis` → `airis-workspace` binary rename (AIRIS suite dispatch, agiletec-inc/airis-workspace feat/cli-namespace).

- `Dockerfile`: `ARG AIRIS_VERSION` 3.6.7 → 4.0.0, verify `airis-workspace --version`
- `mcp-config.json.example`: spawn `airis-workspace mcp`

**Draft until `airis-workspace` 4.0.0 is on crates.io** — cargo-binstall in the image build fails otherwise. Local runtime `mcp-config.json` files need the same one-line edit (gitignored).