### PR TITLE
chore: disable official Supabase MCP server (unused, never authorized)

### DIFF
--- a/config/mcp-config.template.json
+++ b/config/mcp-config.template.json
@@ -111,7 +111,7 @@
       "command": "npx",
       "args": ["-y", "mcp-remote", "https://mcp.supabase.com/mcp"],
       "env": {},
-      "enabled": true,
+      "enabled": false,
       "mode": "cold",
       "description": "Supabase: database, migrations, Edge Functions (OAuth)"
     }

--- a/mcp-config.json.example
+++ b/mcp-config.json.example
@@ -238,7 +238,7 @@
         "${SUPABASE_ACCESS_TOKEN}"
       ],
       "env": {},
-      "enabled": true,
+      "enabled": false,
       "mode": "cold",
       "tools_index": [
         {"name": "query", "description": "Execute SQL query against a Supabase database"},


### PR DESCRIPTION
## What
Set `enabled: false` on the `supabase` server in `config/mcp-config.template.json` and `mcp-config.json.example`.

## Why
- The `supabase` server is the **official Supabase-published MCP** (`mcp-remote https://mcp.supabase.com` OAuth in template / `@supabase/mcp-server-supabase` in example) — **not** our `supabase-selfhost`.
- It is **cold and never authorized** (`env: {}`) → it does not connect today.
- Every tool it exposes (`execute_sql`, `apply_migration`, `deploy_edge_function`, `get_logs`, type generation, project url/anon key) is already covered by the `supabase` CLI + doppler workflow. Wiring OAuth would only add a second auth surface for **zero new capability**.

## Scope
- **Disable, not remove.** Docs / workflows / source / routing-table mentions of `supabase` are left intact — `supabase:query` was already non-functional (cold+unauthorized), so disabling introduces no new broken state; it just stops the server from registering. Full scrub of those ~25 references is a separate option if ever wanted.
- `supabase-selfhost` (separate, working server) — untouched.
- `apps/airis-commands` supabase scaffolding entry (different feature, asserted by its TS tests) — untouched.
- `alembic/versions/003_seed_mcp_servers.py` — not the runtime SoT (per CLAUDE.md, SoT is `mcp-config.json`); applied migration not edited.

## Verify
`jq '.mcpServers.supabase.enabled'` → `false` in both files. After `task docker:restart`, `supabase` no longer appears in `airis-find` while other servers remain.