### PR TITLE
feat(mcp): Microsoft Clarity MCPサーバを登録（cold）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,8 @@ ENCRYPTION_MASTER_KEY=your-32-byte-base64-encoded-key-here
 # Get your free API key at https://tavily.com
 # TAVILY_API_KEY=tvly-xxx
 
+# CLARITY_API_TOKEN=  # Microsoft Clarity Data Export API token (Settings > Data Export). Injected via mcp-config clarity entry.
+
 # Supabase - Database management
 # Get access token at https://supabase.com/dashboard/account/tokens
 # SUPABASE_ACCESS_TOKEN=sbp_xxx

--- a/config/mcp-config.template.json
+++ b/config/mcp-config.template.json
@@ -107,6 +107,19 @@
       "mode": "cold",
       "description": "Stripe API: customers, products, prices, subscriptions (OAuth)"
     },
+    "clarity": {
+      "command": "npx",
+      "args": ["-y", "@microsoft/clarity-mcp-server", "--clarity_api_token=${CLARITY_API_TOKEN}"],
+      "env": {},
+      "enabled": true,
+      "mode": "cold",
+      "description": "Microsoft Clarity Data Export API (10 req/day/project, 3 days, 3 dims). Token via CLI flag from Clarity Settings > Data Export.",
+      "behavior": {
+        "triggers": ["LP離脱", "UX分析", "ヒートマップ", "セッション考察"],
+        "instruction": "Clarityで定性的なLP行動分析。ヒートマップPNG/CSVはダッシュボード手動確認(ここでは非露出)。",
+        "priority": "medium"
+      }
+    },
     "supabase": {
       "command": "npx",
       "args": ["-y", "mcp-remote", "https://mcp.supabase.com/mcp"],

--- a/mcp-config.json.example
+++ b/mcp-config.json.example
@@ -320,6 +320,28 @@
         {"name": "list_invoices", "description": "List invoices with optional filters"}
       ]
     },
+    "clarity": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@microsoft/clarity-mcp-server",
+        "--clarity_api_token=${CLARITY_API_TOKEN}"
+      ],
+      "env": {},
+      "enabled": true,
+      "mode": "cold",
+      "_comment": "Microsoft Clarity Data Export API (10 req/day/project, 3 days, 3 dims). Token via CLI flag from Clarity Settings > Data Export.",
+      "tools_index": [
+        {"name": "query-analytics-dashboard", "description": "Query aggregated Clarity analytics: scroll depth, engagement, traffic, and session metrics."},
+        {"name": "list-session-recordings", "description": "List available Clarity session recordings (metadata only, no playback)."},
+        {"name": "query-documentation-resources", "description": "Query Clarity product documentation resources."}
+      ],
+      "behavior": {
+        "triggers": ["LP離脱", "UX分析", "ヒートマップ", "セッション考察"],
+        "instruction": "Clarityで定性的なLP行動分析。ヒートマップPNG/CSVはダッシュボード手動確認(ここでは非露出)。",
+        "priority": "medium"
+      }
+    },
     "twilio": {
       "command": "npx",
       "args": [


### PR DESCRIPTION
## 目的
corporate LP改善ループの解析基盤として、Microsoft Clarity の定量メトリクスを Claude 等から自然言語で引けるよう、公式 `@microsoft/clarity-mcp-server` を gateway に登録する。

## 変更（追加のみ・37 insertions / 0 deletions）
- `mcp-config.json.example` / `config/mcp-config.template.json`: `mcpServers` に `clarity` エントリ（stripe と同型の cold・secret系書式）。
  - `args: ["-y", "@microsoft/clarity-mcp-server", "--clarity_api_token=${CLARITY_API_TOKEN}"]`
  - トークンは **CLIフラグ埋め込み**（Clarity は専用env名なし）。loader `_expand_env_vars` は args にも適用され、既存 `tavily` の `?tavilyApiKey=${TAVILY_API_KEY}` と同方式で実績あり。
- `.env.example`: `# CLARITY_API_TOKEN=...` コメント行追加（TAVILY に倣う・実値なし）。

## Clarity MCP の提供ツール（3つ）
- `query-analytics-dashboard`（集計: スクロール深度/エンゲージ/トラフィック/セッション）
- `list-session-recordings`（一覧メタのみ・再生なし）
- `query-documentation-resources`
※ **ヒートマップPNG/CSVはMCP非対応**（ダッシュボード手動DL）。Data Export API 制限=**10 req/日/project・3日分・3次元** → 消費は日次バッチ設計推奨。

## 有効化の残作業（このPR単体では動かない）
1. Clarity Settings → Data Export で API トークン生成
2. `CLARITY_API_TOKEN` を Doppler に追加 → gateway の `.env` へ download
3. ランタイム `mcp-config.json`（gitignore・未追跡）に本エントリを反映（example からコピー or 追記）→ `task docker:restart`
`mode: cold` なので以降 `airis-find` / `airis-exec` 経由で自動的にツールが露出。