### PR TITLE
fix: FastAPI 0.137-safe route introspection, lift <0.137 pin (Fixes #191)

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -5,14 +5,7 @@ description = "AIRIS MCP Gateway API - Fixes Docker MCP Gateway initialized noti
 requires-python = ">=3.12"
 
 dependencies = [
-    # FastAPI 0.137+ changed how an empty-path route ("") inside a router
-    # included with a prefix is registered, dropping the prefix-root routes
-    # (e.g. the "/mcp" and "/mcp/" GET/HEAD/DELETE/POST handlers in
-    # api/endpoints/mcp_proxy.py). The Streamable HTTP transport relies on those,
-    # and CI/Docker install with `uv pip install -e .` (lock-ignoring) so they
-    # pick up the newest FastAPI. Cap to the last working line (0.136.x) until
-    # those routes are made 0.137-safe.
-    "fastapi>=0.136.1,<0.137.0",
+    "fastapi>=0.137.1,<1.0.0",
     "uvicorn[standard]>=0.46.0,<1.0.0",
     "httpx>=0.28.1,<1.0.0",
     "pydantic>=2.13.4,<3.0.0",

--- a/apps/api/tests/unit/test_mcp_route_presence.py
+++ b/apps/api/tests/unit/test_mcp_route_presence.py
@@ -1,0 +1,90 @@
+"""
+Route-presence canary for the Streamable HTTP / SSE transports.
+
+FastAPI 0.137 refactored `include_router()` to preserve `APIRouter` /
+`APIRoute` instances instead of cloning them into a flat list: `app.routes`
+now contains opaque `_IncludedRouter` tree nodes for any router mounted with
+`app.include_router(...)`, so naive top-level path checks on `app.routes`
+silently stop finding routes like "/mcp" that live inside a prefixed router
+even though the routes still dispatch correctly at runtime (see issue #191).
+
+This test walks the *effective* route table — recursing into both the old
+(flat, pre-0.137) and new (tree, 0.137+) shapes — so it fails loudly if a
+future FastAPI/Starlette change (or a refactor of our own routers) drops a
+route that a live transport depends on, instead of passing on structure that
+no longer reflects what actually gets served.
+"""
+from app.main import app
+
+
+def iter_effective_routes(router_or_app, prefix=""):
+    """Yield (full_path, methods, route) for every dispatchable route.
+
+    Recurses into FastAPI 0.137+ `_IncludedRouter` nodes (via
+    `original_router` + `include_context.prefix`) and into any other
+    Mount-like object exposing nested `.routes`. On FastAPI <0.137,
+    `app.routes` is already flat with the prefix baked into `route.path`,
+    so the recursion below is a no-op for those routes.
+    """
+    routes = getattr(router_or_app, "routes", None)
+    if not routes:
+        return
+
+    for route in routes:
+        original_router = getattr(route, "original_router", None)
+        if original_router is not None:
+            include_context = getattr(route, "include_context", None)
+            sub_prefix = getattr(include_context, "prefix", "") or ""
+            yield from iter_effective_routes(original_router, prefix + sub_prefix)
+            continue
+
+        path = getattr(route, "path", None)
+        if path is not None:
+            yield prefix + path, getattr(route, "methods", None), route
+            continue
+
+        # Generic Mount-like node with nested routes but no direct path.
+        if getattr(route, "routes", None):
+            yield from iter_effective_routes(route, prefix)
+
+
+def _methods_for(effective_routes, path):
+    methods = set()
+    for full_path, route_methods, _route in effective_routes:
+        if full_path == path and route_methods:
+            methods |= set(route_methods)
+    return methods
+
+
+def test_mcp_root_routes_dispatch_get_post_delete():
+    """The Streamable HTTP transport root must keep GET/POST/DELETE."""
+    effective_routes = list(iter_effective_routes(app))
+
+    mcp_paths_seen = {
+        full_path for full_path, _methods, _route in effective_routes
+        if full_path in {"/mcp", "/mcp/"}
+    }
+    assert mcp_paths_seen, "Expected /mcp or /mcp/ to be registered on the FastAPI app"
+
+    combined_methods = set()
+    for path in ("/mcp", "/mcp/"):
+        combined_methods |= _methods_for(effective_routes, path)
+
+    for required_method in ("GET", "POST", "DELETE"):
+        assert required_method in combined_methods, (
+            f"Expected {required_method} to route to /mcp or /mcp/, "
+            f"got methods={combined_methods}"
+        )
+
+
+def test_sse_routes_dispatch_get_post():
+    """The classic SSE transport must keep GET/POST at /sse."""
+    effective_routes = list(iter_effective_routes(app))
+
+    sse_methods = _methods_for(effective_routes, "/sse")
+    assert sse_methods, "Expected /sse to be registered on the FastAPI app"
+
+    for required_method in ("GET", "POST"):
+        assert required_method in sse_methods, (
+            f"Expected {required_method} to route to /sse, got methods={sse_methods}"
+        )

--- a/apps/api/tests/unit/test_public_routes.py
+++ b/apps/api/tests/unit/test_public_routes.py
@@ -1,32 +1,34 @@
 from app.main import app
+from test_mcp_route_presence import iter_effective_routes
 
 
 def test_public_sse_route_registered():
     """Verify the Codex-compatible /sse passthrough stays wired up."""
     matching_routes = [
-        route for route in app.routes if getattr(route, "path", None) == "/sse"
+        (path, methods) for path, methods, _route in iter_effective_routes(app)
+        if path == "/sse"
     ]
     assert matching_routes, "Expected /sse route to be registered on the FastAPI app"
-    assert any("GET" in getattr(route, "methods", set()) for route in matching_routes)
+    assert any("GET" in (methods or set()) for _path, methods in matching_routes)
 
 
 def test_public_mcp_root_routes_registered():
     """Ensure /mcp root aliases exist for HTTP MCP transports."""
     matching_routes = [
-        route for route in app.routes if getattr(route, "path", None) in {"/mcp", "/mcp/"}
+        (path, methods) for path, methods, _route in iter_effective_routes(app)
+        if path in {"/mcp", "/mcp/"}
     ]
     assert matching_routes, "Expected /mcp routes to be registered on the FastAPI app"
-    for route in matching_routes:
-        methods = getattr(route, "methods", set())
+    for _path, methods in matching_routes:
         assert methods, "Route should advertise supported HTTP methods"
-    assert any("DELETE" in getattr(route, "methods", set()) for route in matching_routes)
+    assert any("DELETE" in (methods or set()) for _path, methods in matching_routes)
 
 
 def test_public_well_known_route_registered():
     """Ensure Streamable HTTP discovery is exposed at the application root."""
     matching_routes = [
-        route for route in app.routes
-        if getattr(route, "path", None) == "/.well-known/{path:path}"
+        (path, methods) for path, methods, _route in iter_effective_routes(app)
+        if path == "/.well-known/{path:path}"
     ]
     assert matching_routes, "Expected root /.well-known proxy route to be registered"
-    assert any("GET" in getattr(route, "methods", set()) for route in matching_routes)
+    assert any("GET" in (methods or set()) for _path, methods in matching_routes)

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -40,7 +40,7 @@ test = [
 requires-dist = [
     { name = "aiosqlite", marker = "extra == 'test'", specifier = ">=0.22.1,<1.0.0" },
     { name = "cryptography", specifier = ">=48.0.0,<49.0.0" },
-    { name = "fastapi", specifier = ">=0.136.1,<0.137.0" },
+    { name = "fastapi", specifier = ">=0.137.1,<1.0.0" },
     { name = "greenlet", marker = "extra == 'test'", specifier = ">=3.5.0,<4.0.0" },
     { name = "httpx", specifier = ">=0.28.1,<1.0.0" },
     { name = "psutil", specifier = ">=7.2.2,<8.0.0" },
@@ -297,7 +297,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.136.3"
+version = "0.139.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -306,9 +306,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/af/a5f50ccfa659ec1802cb4ca842c23f06d906a8cc9aef6016a2caeea3d4ed/fastapi-0.139.0.tar.gz", hash = "sha256:99ab7b2d92223c76d6cf10757ab3f89d45b38267fc20b2a136cf02f6beac3145", size = 423016, upload-time = "2026-07-01T16:35:33.436Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/7c/8e3c6ad324ea5cb36604fc3f968554887891c316d9dfde57761611d907ad/fastapi-0.139.0-py3-none-any.whl", hash = "sha256:cf15e1e9e667ddb0ad63811e60bd11390d1aac838ca4a7a23f421807b2308189", size = 130339, upload-time = "2026-07-01T16:35:32.19Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #191

## What / why — the pin's premise was half-wrong

Investigation with FastAPI 0.139.0 + TestClient shows the `/mcp` `/mcp/` routes **never stopped dispatching at runtime** on 0.137+. What broke: 0.137 refactored `include_router()` to keep an `_IncludedRouter` tree instead of flattening cloned routes into `app.routes`, so flat `app.routes` scans (exactly what `tests/unit/test_public_routes.py` did) silently see nothing — that red test is what motivated commit `4bd3e330`'s pin.

- `pyproject.toml`: `fastapi>=0.137.1,<1.0.0` (0.137.1 floor per changelog fix for empty-path prefixless routers); `uv.lock` re-resolved → fastapi 0.139.0, starlette 1.3.1 (8-line lock diff, no other package moved)
- New `iter_effective_routes()` walker traverses both route-table shapes (flat <0.137, tree 0.137+); `test_public_routes.py` rewritten onto it
- Production routing code unchanged — the existing `""`/`"/"` dual registration in `mcp_proxy.py` was already safe

## Acceptance (independently verified, raw results)

- `uv lock --check` → exit 0; lock resolves fastapi **0.139.0**
- `pytest tests/unit -q` → **387 passed**, exit 0
- Runtime dispatch on 0.139.0: GET `/mcp` 200 / GET `/mcp/` 200 / POST 400 / DELETE 204 — **no 404 on any method×path**
- `tests/integration/test_mcp_server_persistence.py` not run locally (pre-existing: needs the Docker stack + live DB; collection-time `create_async_engine(None)`) — CI is the gate there

**Gate added/tightened:** `tests/unit/test_mcp_route_presence.py` — canary asserting `/mcp` GET/POST/DELETE and `/sse` GET/POST exist across BOTH FastAPI route-table shapes; fails (never skips) if a future upgrade or refactor drops them.