### PR TITLE
fix: registry/catalog/docs drift — stop advertising disabled/nonexistent servers (Fixes #193)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,9 +94,8 @@ When working in a project that uses this gateway, pick tools by this decision fl
 ```
 Need official library docs?    → context7:resolve-library-id → context7:query-docs
 Need current/external info?    → tavily:tavily-search
-Database query or schema?      → supabase:query
+Database query or schema?      → supabase is disabled by default (not authorized); do not call supabase:* unless a human has explicitly enabled it
 Payment/billing?               → stripe:*
-DNS/workers/KV?                → cloudflare:*
 Figma/design?                  → figma:*
 Browser testing/screenshots?   → playwright-cli skill (host Chrome — NOT MCP playwright)
 File generation (docx/xlsx/…)? → claude-api plugin (host filesystem)

--- a/README.md
+++ b/README.md
@@ -119,14 +119,14 @@ AIRIS is not only a central MCP registry. It also distributes operating guidance
 
 ## How It Works
 
-Airis aggregates 20+ MCP servers behind a single endpoint — Streamable HTTP at `/mcp/` for Codex / Claude Code, and SSE at `/sse` for Gemini CLI, Cursor, and Windsurf. Your AI agent connects once and gets access to everything.
+Airis aggregates the MCP servers registered in [`mcp-config.json`](./mcp-config.json) (~24 entries, roughly half enabled by default) behind a single endpoint — Streamable HTTP at `/mcp/` for Codex / Claude Code, and SSE at `/sse` for Gemini CLI, Cursor, and Windsurf. Your AI agent connects once and gets access to everything that's enabled.
 
 ```
 Without Gateway:                          With Gateway:
   claude mcp add stripe ...                 claude mcp add airis ...
-  claude mcp add supabase ...               # Done. 100+ tools available.
-  claude mcp add tavily ...                 # Shared across Gemini, Cursor, etc.
-  ... Manage 20 servers individually ...
+  claude mcp add tavily ...                 # Done. Every enabled tool available.
+  claude mcp add github ...                 # Shared across Gemini, Cursor, etc.
+  ... Manage each server individually ...
 ```
 
 Servers start on-demand when a tool is called and auto-terminate when idle. No resources wasted.
@@ -173,21 +173,20 @@ Claude / Gemini / Cursor / Windsurf
 | **airis-legal** | Japanese court document automation (証拠説明書 / 準備書面) |
 | **fetch** | Fetch a URL and return it as markdown |
 | **tavily** | Web search via Tavily API |
-| **supabase** | Supabase database management |
 | **stripe** | Stripe payments API |
 | **twilio** | Twilio voice/SMS API |
-| **cloudflare** | Cloudflare DNS / Workers / KV |
 | **figma** | Figma design files |
 | **magic** | UI component generation |
 | **chrome-devtools** | Chrome debugging |
 
-### Disabled — auto-enable on first tool call
+### Disabled — not registered, no advertised tools
 
 | Server | Description |
 |--------|-------------|
 | **github** | GitHub API |
 | **postgres** | Direct PostgreSQL access |
 | **memory** | Knowledge graph (entities, relations) |
+| **supabase** | Supabase database management — disabled, never authorized for this deployment |
 | **mindbase** | Local memory substrate (pgvector + Ollama) |
 | **serena** | Semantic code retrieval and editing |
 | **morphllm** | Code editing with warpgrep |

--- a/README.md
+++ b/README.md
@@ -178,19 +178,19 @@ Claude / Gemini / Cursor / Windsurf
 | **figma** | Figma design files |
 | **magic** | UI component generation |
 | **chrome-devtools** | Chrome debugging |
+| **github** | GitHub API |
+| **memory** | Knowledge graph (entities, relations) |
+| **serena** | Semantic code retrieval and editing |
+| **morphllm** | Code editing with warpgrep |
+| **sequential-thinking** | Step-by-step reasoning |
 
 ### Disabled — not registered, no advertised tools
 
 | Server | Description |
 |--------|-------------|
-| **github** | GitHub API |
 | **postgres** | Direct PostgreSQL access |
-| **memory** | Knowledge graph (entities, relations) |
 | **supabase** | Supabase database management — disabled, never authorized for this deployment |
-| **mindbase** | Local memory substrate (pgvector + Ollama) |
-| **serena** | Semantic code retrieval and editing |
-| **morphllm** | Code editing with warpgrep |
-| **sequential-thinking** | Step-by-step reasoning |
+| **mindbase** | Local memory substrate (pgvector + Ollama) — disabled, never authorized for this deployment |
 | **filesystem** | File system operations |
 | **git** | Git operations |
 | **time** | Time utilities |

--- a/apps/api/src/app/api/endpoints/mcp_proxy.py
+++ b/apps/api/src/app/api/endpoints/mcp_proxy.py
@@ -51,7 +51,7 @@ from ...core.behavior_compiler import compile_instructions
 from ...core.config import settings
 from ...core.dynamic_mcp import get_dynamic_mcp, inject_schema_on_validation_error
 from ...core.logging import get_logger
-from ...core.mcp_config_loader import ServerMode
+from ...core.mcp_config_loader import ServerMode, is_discoverable
 from ...core.process_manager import get_process_manager
 from ...core.protocol_logger import protocol_logger
 from ...core.schema_partitioning import schema_partitioner
@@ -1075,7 +1075,11 @@ async def handle_airis_find(rpc_request: Dict[str, Any], session_id: Optional[st
     has_process_servers = any(s.source == "process" for s in dynamic_mcp._servers.values())
     if not has_process_servers:
         logger.info("Server cache empty, refreshing...")
-        # Cache server info for ALL servers (including COLD and disabled)
+        # Cache server info for ALL servers (including COLD and disabled).
+        # Tool discovery below is narrower: policy_disabled servers (e.g.
+        # supabase, mindbase) are excluded so airis-find never advertises
+        # tools that must never run. Plain enabled=False COLD servers (e.g.
+        # stripe) still surface — they auto-enable on first call.
         index_count = 0
         for name in process_manager.get_server_names():
             status = process_manager.get_server_status(name)
@@ -1086,9 +1090,9 @@ async def handle_airis_find(rpc_request: Dict[str, Any], session_id: Optional[st
                 tools_count=status.get("tools_count", 0),
                 source="process"
             )
-            # Also cache tools_index entries for COLD/disabled servers
+            # Also cache tools_index entries for discoverable COLD/disabled servers
             config = process_manager._server_configs.get(name)
-            if config and config.tools_index:
+            if config and is_discoverable(config) and config.tools_index:
                 for tool_entry in config.tools_index:
                     tool_name = tool_entry.get("name", "")
                     if tool_name and tool_name not in dynamic_mcp._tools:
@@ -1382,6 +1386,23 @@ async def handle_airis_exec(rpc_request: Dict[str, Any], session_id: Optional[st
         )
     if process_manager.is_process_server(server_name):
         config = process_manager._server_configs.get(server_name)
+
+        # Policy-disabled servers (e.g. supabase, mindbase) must never run,
+        # even via COLD auto-enable — refuse before touching the process.
+        if config and getattr(config, "policy_disabled", False):
+            logger.warning(f"Refused auto-enable of policy-disabled server for airis-exec: {server_name}")
+            return Response(
+                content=json.dumps({
+                    "jsonrpc": "2.0",
+                    "id": rpc_request.get("id"),
+                    "error": {
+                        "code": -32001,
+                        "message": f"server '{server_name}' is policy-disabled and cannot be auto-enabled"
+                    }
+                }),
+                status_code=200,
+                media_type="application/json"
+            )
 
         # Auto-enable COLD mode servers on first airis-exec call
         if config and config.mode == ServerMode.COLD and not config.enabled:

--- a/apps/api/src/app/core/dynamic_mcp.py
+++ b/apps/api/src/app/core/dynamic_mcp.py
@@ -8,6 +8,7 @@ from typing import Any, Optional
 from dataclasses import dataclass, field
 
 from .logging import get_logger
+from .mcp_config_loader import is_discoverable
 from .toolset_catalog import ToolsetInfo, build_toolset_index
 
 logger = get_logger(__name__)
@@ -224,13 +225,14 @@ class DynamicMCP:
                         source="docker"
                     )
 
-        # Cache tools_index from ALL enabled servers (including COLD)
-        # This enables discovery without starting servers. Disabled servers
-        # are excluded so airis-find never surfaces tools that cannot be run.
+        # Cache tools_index from ALL discoverable servers (including COLD
+        # and disabled-but-not-policy-disabled, e.g. stripe). This enables
+        # discovery without starting servers. Only policy_disabled servers
+        # (e.g. supabase, mindbase) are excluded — see is_discoverable().
         index_count = 0
         for name in process_manager.get_server_names():
             config = process_manager._server_configs.get(name)
-            if config and config.enabled and config.tools_index:
+            if config and is_discoverable(config) and config.tools_index:
                 for tool_entry in config.tools_index:
                     tool_name = tool_entry.get("name", "")
                     if tool_name and tool_name not in new_tools:
@@ -296,7 +298,7 @@ class DynamicMCP:
                 if name in excluded:
                     continue
                 config = process_manager._server_configs.get(name)
-                if config and config.tools_index:
+                if config and is_discoverable(config) and config.tools_index:
                     tools = [
                         t.get("name") for t in config.tools_index
                         if t.get("name") and t.get("name") not in hot_tools
@@ -587,6 +589,15 @@ class DynamicMCP:
         logger.info(f"Auto-discovered COLD tool '{tool_name}' on server '{server_name}'")
 
         config = process_manager._server_configs.get(server_name)
+        if config and getattr(config, "policy_disabled", False):
+            logger.warning(f"Refused auto-enable of policy-disabled server: {server_name}")
+            return {
+                "error": {
+                    "code": -32001,
+                    "message": f"server '{server_name}' is policy-disabled and cannot be auto-enabled",
+                }
+            }
+
         if config and config.mode == ServerMode.COLD and not config.enabled:
             logger.info(f"Auto-enabling COLD server: {server_name}")
             await process_manager.enable_server(server_name)

--- a/apps/api/src/app/core/dynamic_mcp.py
+++ b/apps/api/src/app/core/dynamic_mcp.py
@@ -224,12 +224,13 @@ class DynamicMCP:
                         source="docker"
                     )
 
-        # Cache tools_index from ALL servers (including COLD/disabled)
-        # This enables discovery without starting servers
+        # Cache tools_index from ALL enabled servers (including COLD)
+        # This enables discovery without starting servers. Disabled servers
+        # are excluded so airis-find never surfaces tools that cannot be run.
         index_count = 0
         for name in process_manager.get_server_names():
             config = process_manager._server_configs.get(name)
-            if config and config.tools_index:
+            if config and config.enabled and config.tools_index:
                 for tool_entry in config.tools_index:
                     tool_name = tool_entry.get("name", "")
                     if tool_name and tool_name not in new_tools:

--- a/apps/api/src/app/core/mcp_config_loader.py
+++ b/apps/api/src/app/core/mcp_config_loader.py
@@ -60,6 +60,11 @@ class McpServerConfig:
     args: list[str]
     env: dict[str, str]
     enabled: bool
+    # Hard policy gate: True means the server must NEVER run, even via COLD
+    # auto-enable (e.g. supabase, mindbase). Distinct from `enabled=False`,
+    # which just means "not started yet" for COLD/lazy servers (e.g. stripe)
+    # that auto-enable transparently on first tool call.
+    policy_disabled: bool = False
     mode: ServerMode = ServerMode.COLD  # Default to cold
     cwd: Optional[str] = None
     runner: Optional[str] = None  # "local" or "remote" for profile-based servers
@@ -96,6 +101,19 @@ class McpServerConfig:
         if self.adaptive_ttl_enabled is not None:
             config.adaptive_ttl_enabled = self.adaptive_ttl_enabled
         return config
+
+
+def is_discoverable(config) -> bool:
+    """
+    Whether a server's tools may surface in discovery indexes (airis-find,
+    toolset catalog, airis-exec listing).
+
+    Only `policy_disabled` servers (never authorized to run, e.g. supabase,
+    mindbase) are excluded. Plain `enabled=False` COLD/lazy servers (e.g.
+    stripe) remain discoverable — they auto-enable transparently on first
+    call, so hiding them from discovery would break that flow.
+    """
+    return not getattr(config, "policy_disabled", False)
 
 
 def classify_server_type(command: str) -> ServerType:
@@ -160,6 +178,7 @@ def load_mcp_config(config_path: Optional[str] = None) -> dict[str, McpServerCon
     for name, server_def in mcp_servers.items():
         env = server_def.get("env", {})
         enabled = server_def.get("enabled", False)
+        policy_disabled = server_def.get("policy_disabled", False)
         mode_str = server_def.get("mode", "cold")
 
         # Check for profile-based configuration
@@ -225,6 +244,7 @@ def load_mcp_config(config_path: Optional[str] = None) -> dict[str, McpServerCon
             args=expanded_args,
             env=expanded_env,
             enabled=enabled,
+            policy_disabled=policy_disabled,
             mode=mode,
             runner=runner,
             idle_timeout=idle_timeout,

--- a/apps/api/src/app/core/toolset_catalog.py
+++ b/apps/api/src/app/core/toolset_catalog.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from .logging import get_logger
+from .mcp_config_loader import is_discoverable
 
 logger = get_logger(__name__)
 
@@ -42,9 +43,11 @@ def build_toolset_index(server_configs: dict[str, object]) -> dict[str, ToolsetI
     toolsets: dict[str, ToolsetInfo] = {}
 
     for server_name, config in server_configs.items():
-        if not getattr(config, "enabled", False):
-            # Disabled servers cannot execute tool calls, so their tools
-            # must not surface in the discoverable toolset catalog.
+        if not is_discoverable(config):
+            # Policy-disabled servers (e.g. supabase, mindbase) must never
+            # run, so their tools must not surface in the discoverable
+            # toolset catalog. Plain enabled=False COLD servers (e.g.
+            # stripe) remain discoverable — they auto-enable on first call.
             continue
 
         indexed_tools = [

--- a/apps/api/src/app/core/toolset_catalog.py
+++ b/apps/api/src/app/core/toolset_catalog.py
@@ -42,6 +42,11 @@ def build_toolset_index(server_configs: dict[str, object]) -> dict[str, ToolsetI
     toolsets: dict[str, ToolsetInfo] = {}
 
     for server_name, config in server_configs.items():
+        if not getattr(config, "enabled", False):
+            # Disabled servers cannot execute tool calls, so their tools
+            # must not surface in the discoverable toolset catalog.
+            continue
+
         indexed_tools = [
             entry.get("name")
             for entry in getattr(config, "tools_index", []) or []

--- a/apps/api/tests/unit/test_cold_tool_auto_discovery.py
+++ b/apps/api/tests/unit/test_cold_tool_auto_discovery.py
@@ -20,7 +20,8 @@ from app.core.mcp_config_loader import McpServerConfig, ServerMode
 
 
 def _make_config(name: str, *, enabled: bool = True, mode=ServerMode.COLD,
-                 tools_index: list[dict] | None = None) -> McpServerConfig:
+                 tools_index: list[dict] | None = None,
+                 policy_disabled: bool = False) -> McpServerConfig:
     return McpServerConfig(
         name=name,
         server_type="process",
@@ -28,6 +29,7 @@ def _make_config(name: str, *, enabled: bool = True, mode=ServerMode.COLD,
         args=["test-server"],
         env={},
         enabled=enabled,
+        policy_disabled=policy_disabled,
         mode=mode,
         tools_index=tools_index or [],
     )
@@ -267,6 +269,52 @@ def test_unknown_tool_falls_through_to_gateway(monkeypatch):
     )
     assert resp.status_code == 503
     assert len(fallthrough_called) == 1, "Expected fallthrough to stream bridge"
+
+
+def test_policy_disabled_server_refuses_auto_enable(monkeypatch):
+    """A tools/call for a tool on a policy_disabled server (e.g. supabase,
+    mindbase) must be refused with a JSON-RPC error and must NOT actually
+    enable/start the server (issue #193 review finding 1)."""
+    pm = ProcessManager()
+    pm._initialized = True
+    pm._server_configs["supabase"] = _make_config(
+        "supabase", mode=ServerMode.COLD, enabled=False, policy_disabled=True,
+        tools_index=[{"name": "query", "description": "Execute a SQL query"}],
+    )
+    _wire_process_manager(pm)
+
+    call_log = []
+
+    async def fake_enable_server(name):
+        call_log.append(f"enable:{name}")
+
+    async def fake_call_tool_on_server(server_name, tool_name, arguments):
+        call_log.append(f"call:{server_name}:{tool_name}")
+        return {"result": {"content": [{"type": "text", "text": "should not be reached"}]}}
+
+    monkeypatch.setattr(pm, "enable_server", fake_enable_server)
+    monkeypatch.setattr(pm, "call_tool_on_server", fake_call_tool_on_server)
+
+    dmcp = DynamicMCP()
+
+    tc = _make_client(pm, dmcp, monkeypatch)
+
+    resp = tc.post(
+        "/mcp/",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "query", "arguments": {}},
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "error" in body
+    assert "policy-disabled" in body["error"]["message"]
+    assert "supabase" in body["error"]["message"]
+    assert call_log == [], "server must never be enabled or called when policy_disabled"
+    assert pm._server_configs["supabase"].enabled is False
 
 
 def test_auto_discovery_error_handling(monkeypatch):

--- a/apps/api/tests/unit/test_is_discoverable.py
+++ b/apps/api/tests/unit/test_is_discoverable.py
@@ -1,0 +1,37 @@
+"""Tests for is_discoverable() (issue #193 review).
+
+is_discoverable() is the single predicate shared by every discovery index
+seeding site (dynamic_mcp.refresh_cache_hot_only, toolset_catalog.build_toolset_index,
+mcp_proxy.handle_airis_find fallback, dynamic_mcp.build_compact_tool_listing
+fallback). Only `policy_disabled` servers (never authorized to run, e.g.
+supabase, mindbase) are excluded — plain `enabled: false` COLD/lazy servers
+(e.g. stripe) remain discoverable.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.core.mcp_config_loader import is_discoverable
+
+
+@dataclass
+class _FakeConfig:
+    policy_disabled: bool = False
+
+
+def test_default_config_is_discoverable():
+    assert is_discoverable(_FakeConfig()) is True
+
+
+def test_policy_disabled_config_is_not_discoverable():
+    assert is_discoverable(_FakeConfig(policy_disabled=True)) is False
+
+
+def test_config_missing_policy_disabled_attr_is_discoverable():
+    """Objects without the attribute at all (e.g. a stale/duck-typed config)
+    must default to discoverable — matches the dataclass field default."""
+
+    class _NoAttr:
+        pass
+
+    assert is_discoverable(_NoAttr()) is True

--- a/apps/api/tests/unit/test_registry_docs_drift.py
+++ b/apps/api/tests/unit/test_registry_docs_drift.py
@@ -22,7 +22,11 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[4]
 
 # `server:tool` call syntax, e.g. "supabase:query", "stripe:create_customer".
-TOOL_REF_PATTERN = re.compile(r"\b([a-z][a-z0-9-]+):([a-z][a-z0-9_-]+)\b")
+# Also matches the `server:*` wildcard form (e.g. "figma:*", "cloudflare:*")
+# used in routing-guide prose — a plain trailing `\b` never matches after
+# `*` (both neighbours are non-word chars), so a negative lookahead is used
+# instead to bound the match for both the alnum and wildcard tool forms.
+TOOL_REF_PATTERN = re.compile(r"\b([a-z][a-z0-9-]+):(\*|[a-z][a-z0-9_-]+)(?![a-z0-9_-])")
 
 # `[server]` routing-tag syntax used in workflows/*.yaml mcp_instructions bullets.
 BRACKET_REF_PATTERN = re.compile(r"\[([a-z][a-z0-9-]+)\]")
@@ -34,14 +38,6 @@ BRACKET_REF_PATTERN = re.compile(r"\[([a-z][a-z0-9-]+)\]")
 # scope). Always a violation, even if a disabled stub happens to exist in
 # mcp-config.json.example and even if the line carries a caveat.
 FORBIDDEN_SERVERS = {"cloudflare"}
-
-# Servers that are `enabled: false` for a POLICY reason (never authorized /
-# not wired up), not just "COLD and not yet lazily started". Most COLD
-# servers (stripe, twilio, postgres, ...) start `enabled: false` and are
-# EXPECTED to be advertised — they auto-enable transparently on first call
-# (see CLAUDE.md "Dynamic MCP"). Only servers in this curated set must never
-# be routed to without an explicit disabled-server caveat in the same line.
-POLICY_DISABLED_SERVERS = {"supabase", "mindbase"}
 
 # Phrases that indicate a disabled-server mention is a deliberate, honest
 # caveat ("don't call this, it's off") rather than a routing instruction.
@@ -66,16 +62,24 @@ SCAN_FILES = [
 ]
 
 
-def _load_registry() -> tuple[set[str], set[str]]:
-    """Return (all_servers, enabled_servers) from the tracked registry mirror."""
+def _load_registry() -> tuple[set[str], set[str], set[str]]:
+    """Return (all_servers, enabled_servers, policy_disabled_servers) from the
+    tracked registry mirror.
+
+    `policy_disabled_servers` is DERIVED directly from each server's
+    `policy_disabled` flag (e.g. supabase, mindbase) rather than a hardcoded
+    Python set, so this gate can't silently drift from the registry itself —
+    a server can only become policy-disabled by an explicit registry edit.
+    """
     data = json.loads((REPO_ROOT / "mcp-config.json.example").read_text())
     servers = data["mcpServers"]
     all_servers = set(servers.keys())
     enabled_servers = {name for name, cfg in servers.items() if cfg.get("enabled")}
-    return all_servers, enabled_servers
+    policy_disabled_servers = {name for name, cfg in servers.items() if cfg.get("policy_disabled")}
+    return all_servers, enabled_servers, policy_disabled_servers
 
 
-ALL_SERVERS, ENABLED_SERVERS = _load_registry()
+ALL_SERVERS, ENABLED_SERVERS, POLICY_DISABLED_SERVERS = _load_registry()
 
 
 def _line_is_disqualified(line: str) -> bool:

--- a/apps/api/tests/unit/test_registry_docs_drift.py
+++ b/apps/api/tests/unit/test_registry_docs_drift.py
@@ -1,0 +1,209 @@
+"""
+Registry/docs drift gate (issue #193).
+
+The registry SSoT is `mcp-config.json` (runtime, gitignored). Its tracked
+mirror is `mcp-config.json.example`. Docs, workflows, and static catalogs
+must never route agents to a server that doesn't exist in the registry, or
+that exists but is `enabled: false` there (unless the text explicitly warns
+that the server is disabled).
+
+Scope note: `config/gateway-config.yaml` is intentionally EXCLUDED from this
+scan. It is slated for removal in issue #196 and is out of scope here.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+# `server:tool` call syntax, e.g. "supabase:query", "stripe:create_customer".
+TOOL_REF_PATTERN = re.compile(r"\b([a-z][a-z0-9-]+):([a-z][a-z0-9_-]+)\b")
+
+# `[server]` routing-tag syntax used in workflows/*.yaml mcp_instructions bullets.
+BRACKET_REF_PATTERN = re.compile(r"\[([a-z][a-z0-9-]+)\]")
+
+# Servers that must never be advertised in routing contexts, full stop —
+# either because they don't exist in the registry, or because the project
+# has explicitly decided not to support them (issue #193: cloudflare would
+# need real API credentials to register, which is a human decision, out of
+# scope). Always a violation, even if a disabled stub happens to exist in
+# mcp-config.json.example and even if the line carries a caveat.
+FORBIDDEN_SERVERS = {"cloudflare"}
+
+# Servers that are `enabled: false` for a POLICY reason (never authorized /
+# not wired up), not just "COLD and not yet lazily started". Most COLD
+# servers (stripe, twilio, postgres, ...) start `enabled: false` and are
+# EXPECTED to be advertised — they auto-enable transparently on first call
+# (see CLAUDE.md "Dynamic MCP"). Only servers in this curated set must never
+# be routed to without an explicit disabled-server caveat in the same line.
+POLICY_DISABLED_SERVERS = {"supabase", "mindbase"}
+
+# Phrases that indicate a disabled-server mention is a deliberate, honest
+# caveat ("don't call this, it's off") rather than a routing instruction.
+DISQUALIFIERS = (
+    "disabled",
+    "not authorized",
+    "never authorized",
+    "do not call",
+    "not enabled",
+    "removed",
+    "not support",
+    "out of scope",
+)
+
+SCAN_FILES = [
+    "README.md",
+    "CLAUDE.md",
+    "docs/architecture.md",
+    "config/toolsets.json",
+    "catalogs/airis-catalog.yaml",
+    *sorted(str(p.relative_to(REPO_ROOT)) for p in (REPO_ROOT / "workflows").glob("*.yaml")),
+]
+
+
+def _load_registry() -> tuple[set[str], set[str]]:
+    """Return (all_servers, enabled_servers) from the tracked registry mirror."""
+    data = json.loads((REPO_ROOT / "mcp-config.json.example").read_text())
+    servers = data["mcpServers"]
+    all_servers = set(servers.keys())
+    enabled_servers = {name for name, cfg in servers.items() if cfg.get("enabled")}
+    return all_servers, enabled_servers
+
+
+ALL_SERVERS, ENABLED_SERVERS = _load_registry()
+
+
+def _line_is_disqualified(line: str) -> bool:
+    lowered = line.lower()
+    return any(phrase in lowered for phrase in DISQUALIFIERS)
+
+
+def _scan_text_for_routing_violations(relpath: str, text: str) -> list[str]:
+    """Find server references in `text` that route to a missing/disabled server."""
+    violations: list[str] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        candidates: set[str] = set()
+        for m in TOOL_REF_PATTERN.finditer(line):
+            # Skip connection-string userinfo like "user:pass@host" — not a
+            # server:tool call, just credentials embedded in a URL.
+            if line[m.end() : m.end() + 1] == "@":
+                continue
+            candidates.add(m.group(1))
+        for m in BRACKET_REF_PATTERN.finditer(line):
+            candidates.add(m.group(1))
+
+        for server in candidates:
+            # Ignore words that happen to match the pattern but aren't a
+            # tracked, forbidden, or known-missing server name (URLs, code
+            # identifiers, timestamps, etc.) — this is what keeps the
+            # matcher pragmatic.
+            if server not in ALL_SERVERS and server not in FORBIDDEN_SERVERS:
+                continue
+
+            if server in FORBIDDEN_SERVERS:
+                # Never supported here (issue #193): always a violation,
+                # regardless of whether a disabled stub exists in the
+                # registry mirror.
+                violations.append(
+                    f"{relpath}:{lineno}: routes to '{server}', which this "
+                    f"project has decided not to support — {line.strip()!r}"
+                )
+                continue
+
+            if server not in ALL_SERVERS:
+                # Missing server not covered by FORBIDDEN_SERVERS: always a violation.
+                violations.append(
+                    f"{relpath}:{lineno}: routes to '{server}', which does not "
+                    f"exist in mcp-config.json.example — {line.strip()!r}"
+                )
+                continue
+
+            if (
+                server in POLICY_DISABLED_SERVERS
+                and server not in ENABLED_SERVERS
+                and not _line_is_disqualified(line)
+            ):
+                violations.append(
+                    f"{relpath}:{lineno}: routes to '{server}', which is "
+                    f"enabled:false (policy-disabled) in mcp-config.json.example "
+                    f"and the line carries no disabled-server caveat — {line.strip()!r}"
+                )
+
+        # Also catch bare mentions of forbidden servers that aren't in
+        # `server:tool` or `[server]` syntax — e.g. a markdown table row
+        # "| **cloudflare** | ... |" or prose "DNS/workers → cloudflare".
+        for server in FORBIDDEN_SERVERS:
+            if re.search(rf"\b{re.escape(server)}\b", line, re.IGNORECASE) and not _line_is_disqualified(line):
+                violations.append(
+                    f"{relpath}:{lineno}: mentions '{server}', which this "
+                    f"project has decided not to support — {line.strip()!r}"
+                )
+    return violations
+
+
+def test_all_servers_and_enabled_servers_are_populated():
+    """Sanity check that the registry mirror actually parsed."""
+    assert len(ALL_SERVERS) >= 10
+    assert len(ENABLED_SERVERS) >= 5
+    assert ENABLED_SERVERS <= ALL_SERVERS
+
+
+@pytest.mark.parametrize("relpath", SCAN_FILES)
+def test_no_routing_references_to_missing_or_disabled_servers(relpath: str):
+    path = REPO_ROOT / relpath
+    assert path.exists(), f"expected scan target {relpath} to exist"
+
+    text = path.read_text()
+    violations = _scan_text_for_routing_violations(relpath, text)
+
+    assert not violations, "Registry/docs drift found:\n" + "\n".join(violations)
+
+
+def test_toolsets_json_keys_reference_real_registry_servers():
+    """config/toolsets.json is keyed by server name — every key must exist in
+    the registry and none may be a forbidden server (catches phantom entries
+    like the old 'cloudflare' block)."""
+    data = json.loads((REPO_ROOT / "config" / "toolsets.json").read_text())
+    keys = set(data.keys())
+    phantom = (keys - ALL_SERVERS) | (keys & FORBIDDEN_SERVERS)
+    assert not phantom, f"toolsets.json references servers not in the registry: {phantom}"
+
+
+def test_airis_catalog_yaml_registry_keys_reference_real_registry_servers():
+    """catalogs/airis-catalog.yaml is keyed by server name under `registry` —
+    every key must exist in mcp-config.json.example and none may be a
+    forbidden server (catches phantom entries like the old 'cloudflare' block)."""
+    data = yaml.safe_load((REPO_ROOT / "catalogs" / "airis-catalog.yaml").read_text())
+    registry_keys = set(data.get("registry", {}).keys())
+    phantom = (registry_keys - ALL_SERVERS) | (registry_keys & FORBIDDEN_SERVERS)
+    assert not phantom, f"airis-catalog.yaml references servers not in the registry: {phantom}"
+
+
+def test_airis_catalog_yaml_disabled_servers_are_annotated():
+    """Any catalog entry for a disabled registry server must carry a nearby
+    'disabled' annotation, so a reader/agent doesn't assume it's callable."""
+    raw = (REPO_ROOT / "catalogs" / "airis-catalog.yaml").read_text()
+    data = yaml.safe_load(raw)
+    registry_keys = set(data.get("registry", {}).keys())
+    disabled_in_catalog = registry_keys & POLICY_DISABLED_SERVERS
+
+    lines = raw.splitlines()
+    for server in disabled_in_catalog:
+        key_pattern = re.compile(rf"^  {re.escape(server)}:\s*$")
+        key_lineno = next(
+            (i for i, line in enumerate(lines) if key_pattern.match(line)), None
+        )
+        assert key_lineno is not None, f"could not locate top-level key for {server}"
+
+        # Look at the block of lines immediately preceding the key for a
+        # disabled-server caveat (comment annotation).
+        window = lines[max(0, key_lineno - 10) : key_lineno]
+        assert any(_line_is_disqualified(line) for line in window), (
+            f"catalogs/airis-catalog.yaml: '{server}' is enabled:false in the "
+            f"registry but has no disabled-server annotation above its entry"
+        )

--- a/apps/api/tests/unit/test_toolset_catalog.py
+++ b/apps/api/tests/unit/test_toolset_catalog.py
@@ -12,6 +12,7 @@ from app.core.toolset_catalog import build_toolset_index
 class _FakeConfig:
     tools_index: list[dict]
     enabled: bool = True
+    policy_disabled: bool = False
 
 
 def _stub_seed_catalog(seed: dict | None = None):
@@ -123,12 +124,14 @@ def test_tools_outside_indexed_list_are_ignored_from_seed():
     assert result["stripe.payments"].tools == ["create_payment"]
 
 
-def test_disabled_server_is_excluded_from_toolset_index():
-    """Disabled servers must never surface tools in the discoverable catalog
-    (issue #193: airis-find was advertising tools of enabled:false servers)."""
+def test_policy_disabled_server_is_excluded_from_toolset_index():
+    """Policy-disabled servers must never surface tools in the discoverable
+    catalog (issue #193 review: airis-find was advertising tools of
+    policy_disabled servers like supabase/mindbase)."""
     configs = {
         "supabase": _FakeConfig(
             enabled=False,
+            policy_disabled=True,
             tools_index=[{"name": "query"}, {"name": "list_tables"}],
         ),
         "github": _FakeConfig(
@@ -141,6 +144,25 @@ def test_disabled_server_is_excluded_from_toolset_index():
 
     assert list(result.keys()) == ["github.default"]
     assert "supabase.default" not in result
+
+
+def test_cold_lazy_server_disabled_but_not_policy_disabled_is_included():
+    """Regression guard for the PR #201 revert: COLD servers that are
+    `enabled: false` at rest but auto-enable transparently on first
+    airis-exec call (e.g. stripe) must still surface in the discoverable
+    toolset index — hiding them would break discover-then-auto-start."""
+    configs = {
+        "stripe": _FakeConfig(
+            enabled=False,
+            policy_disabled=False,
+            tools_index=[{"name": "create_payment"}],
+        ),
+    }
+    with _stub_seed_catalog({}):
+        result = build_toolset_index(configs)
+
+    assert "stripe.default" in result
+    assert result["stripe.default"].tools == ["create_payment"]
 
 
 def test_toolsets_with_no_matching_tools_are_skipped():

--- a/apps/api/tests/unit/test_toolset_catalog.py
+++ b/apps/api/tests/unit/test_toolset_catalog.py
@@ -11,6 +11,7 @@ from app.core.toolset_catalog import build_toolset_index
 @dataclass
 class _FakeConfig:
     tools_index: list[dict]
+    enabled: bool = True
 
 
 def _stub_seed_catalog(seed: dict | None = None):
@@ -120,6 +121,26 @@ def test_tools_outside_indexed_list_are_ignored_from_seed():
         result = build_toolset_index(configs)
 
     assert result["stripe.payments"].tools == ["create_payment"]
+
+
+def test_disabled_server_is_excluded_from_toolset_index():
+    """Disabled servers must never surface tools in the discoverable catalog
+    (issue #193: airis-find was advertising tools of enabled:false servers)."""
+    configs = {
+        "supabase": _FakeConfig(
+            enabled=False,
+            tools_index=[{"name": "query"}, {"name": "list_tables"}],
+        ),
+        "github": _FakeConfig(
+            enabled=True,
+            tools_index=[{"name": "get_issue"}],
+        ),
+    }
+    with _stub_seed_catalog({}):
+        result = build_toolset_index(configs)
+
+    assert list(result.keys()) == ["github.default"]
+    assert "supabase.default" not in result
 
 
 def test_toolsets_with_no_matching_tools_are_skipped():

--- a/catalogs/airis-catalog.yaml
+++ b/catalogs/airis-catalog.yaml
@@ -7,6 +7,13 @@ registry:
   # NOTE: airis-agent has been integrated into airis-mcp-gateway as native tools
   # (airis-confidence, airis-repo-index, airis-suggest, airis-route)
 
+  # DISABLED (issue #193): mindbase is `enabled: false` in mcp-config.json —
+  # never authorized for this deployment. This catalog entry is kept so the
+  # Docker MCP Gateway definition matches the real image/config, but it must
+  # NOT be advertised as discoverable/callable while the registry entry is
+  # disabled. `dynamic_mcp.py` / `toolset_catalog.py` filter disabled servers
+  # out of airis-find results at runtime; this comment documents why the
+  # entry still exists here.
   mindbase:
     title: MindBase MCP Server
     description: Mindbase knowledge graph operations with vector search
@@ -79,36 +86,7 @@ registry:
 
   # === INFRASTRUCTURE SERVERS ===
 
-  cloudflare:
-    title: Cloudflare MCP Server
-    description: Manage Cloudflare DNS, Workers, KV, R2, D1 via MCP
-    type: process
-    command: ["npx", "@cloudflare/mcp-server-cloudflare@latest"]
-    category: Infrastructure
-    readme: https://github.com/cloudflare/mcp-server-cloudflare
-    tools:
-      - name: dns_record_create
-      - name: dns_record_list
-      - name: dns_record_delete
-      - name: zone_list
-      - name: kv_namespace_list
-      - name: kv_get
-      - name: kv_put
-      - name: r2_bucket_list
-      - name: worker_list
-      - name: worker_deploy
-    config:
-      - name: cloudflare_api_token
-        type: string
-        description: Cloudflare API Token with DNS edit permissions
-        required: true
-      - name: cloudflare_account_id
-        type: string
-        description: Cloudflare Account ID
-        required: true
-    env:
-      - name: CLOUDFLARE_API_TOKEN
-        value: '{{cloudflare_api_token}}'
-      - name: CLOUDFLARE_ACCOUNT_ID
-        value: '{{cloudflare_account_id}}'
+  # NOTE: cloudflare was removed (issue #193) — no cloudflare entry exists in
+  # mcp-config.json and registering one requires API credentials, which is a
+  # human decision. Re-add here only alongside a real mcp-config.json entry.
 

--- a/catalogs/airis-catalog.yaml
+++ b/catalogs/airis-catalog.yaml
@@ -7,13 +7,16 @@ registry:
   # NOTE: airis-agent has been integrated into airis-mcp-gateway as native tools
   # (airis-confidence, airis-repo-index, airis-suggest, airis-route)
 
-  # DISABLED (issue #193): mindbase is `enabled: false` in mcp-config.json —
-  # never authorized for this deployment. This catalog entry is kept so the
+  # DISABLED (issue #193): mindbase is `policy_disabled: true` in
+  # mcp-config.json — never authorized for this deployment, and must never
+  # auto-enable even via COLD lazy-start. This catalog entry is kept so the
   # Docker MCP Gateway definition matches the real image/config, but it must
   # NOT be advertised as discoverable/callable while the registry entry is
-  # disabled. `dynamic_mcp.py` / `toolset_catalog.py` filter disabled servers
-  # out of airis-find results at runtime; this comment documents why the
-  # entry still exists here.
+  # policy-disabled. `dynamic_mcp.py` / `toolset_catalog.py` filter only
+  # `policy_disabled` servers out of airis-find results at runtime via
+  # `is_discoverable()` — plain `enabled: false` COLD/lazy servers (e.g.
+  # stripe) are NOT filtered, since they auto-enable transparently on first
+  # call. This comment documents why the mindbase entry still exists here.
   mindbase:
     title: MindBase MCP Server
     description: Mindbase knowledge graph operations with vector search

--- a/config/mcp-config.template.json
+++ b/config/mcp-config.template.json
@@ -12,6 +12,7 @@
         "MINDBASE_URL": "${MINDBASE_URL:-http://localhost:18003}"
       },
       "enabled": true,
+      "policy_disabled": true,
       "mode": "hot",
       "description": "Long-term memory with semantic search"
     },
@@ -112,6 +113,7 @@
       "args": ["-y", "mcp-remote", "https://mcp.supabase.com/mcp"],
       "env": {},
       "enabled": false,
+      "policy_disabled": true,
       "mode": "cold",
       "description": "Supabase: database, migrations, Edge Functions (OAuth)"
     }

--- a/config/toolsets.json
+++ b/config/toolsets.json
@@ -82,22 +82,6 @@
       }
     }
   },
-  "cloudflare": {
-    "toolsets": {
-      "kv": {
-        "summary": "Cloudflare KV operations",
-        "tools": ["cloudflare_kv_get", "cloudflare_kv_put"]
-      },
-      "workers": {
-        "summary": "Cloudflare Workers inspection",
-        "tools": ["cloudflare_workers_list"]
-      },
-      "dns": {
-        "summary": "Cloudflare DNS inspection",
-        "tools": ["cloudflare_dns_records_list"]
-      }
-    }
-  },
   "github": {
     "toolsets": {
       "issues": {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,8 +88,8 @@ tool's argument schema before calling `airis-exec`.
 | State | Behavior | Examples |
 |-------|----------|----------|
 | **HOT** | Pre-warmed at startup, always listed in `tools/list`, never idle-killed | `context7`, `airis-mcp-gateway-control`, `airis-workspace` |
-| **COLD** | Started on first tool call, stopped after idle timeout, restarted transparently | Stripe, Supabase, Tavily, Cloudflare, browser automation |
-| **Disabled** | Gated by policy or absent credentials | dangerous write/admin integrations, niche providers |
+| **COLD** | Started on first tool call, stopped after idle timeout, restarted transparently | Stripe, Tavily, browser automation |
+| **Disabled** | Gated by policy or absent credentials | Supabase (never authorized), dangerous write/admin integrations, niche providers |
 
 ```
 Claude Code
@@ -159,10 +159,10 @@ Rather than exposing every tool from a large server up front, expose a small num
 coherent capability slices:
 
 - `stripe.customers`, `stripe.payments`, `stripe.billing`
-- `supabase.sql`, `supabase.auth`, `supabase.storage`
+- `github.issues`, `github.prs`, `github.repos`
 
 Tools remain the actual call boundary (`stripe:create_customer`,
-`supabase:execute_sql`) — toolsets are only the exposure boundary. This preserves
+`github:create_issue`) — toolsets are only the exposure boundary. This preserves
 precision while avoiding the cost of showing every tool at startup.
 
 ### Target request flow

--- a/mcp-config.json.example
+++ b/mcp-config.json.example
@@ -132,6 +132,7 @@
       ],
       "env": {},
       "enabled": false,
+      "policy_disabled": true,
       "mode": "cold",
       "_comment": "Managed by Docker MCP Gateway via airis-catalog.yaml",
       "tools_index": [
@@ -239,6 +240,7 @@
       ],
       "env": {},
       "enabled": false,
+      "policy_disabled": true,
       "mode": "cold",
       "tools_index": [
         {"name": "query", "description": "Execute SQL query against a Supabase database"},
@@ -411,6 +413,31 @@
         {"name": "get_audio_status", "description": "Non-blocking probe for the current Audio Overview state of a notebook"},
         {"name": "download_audio", "description": "Save the completed Audio Overview to disk as a .m4a file"}
       ]
+    },
+    "figma": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "figma-developer-mcp",
+        "--figma-api-key=${FIGMA_API_KEY}",
+        "--stdio"
+      ],
+      "env": {},
+      "enabled": true,
+      "mode": "cold",
+      "_comment": "Framelink figma-developer-mcp; set FIGMA_API_KEY. Wiring not yet verified against the live runtime config — TODO: populate tools_index once catalogued (do not guess tool names).",
+      "tools_index": []
+    },
+    "airis-legal": {
+      "command": "node",
+      "args": [
+        "/app/airis-legal/index.js"
+      ],
+      "env": {},
+      "enabled": true,
+      "mode": "cold",
+      "_comment": "agiletec-inc/airis-legal (証拠説明書/準備書面 automation). Wiring and tool names not yet verified against the live runtime config — TODO: populate tools_index once catalogued.",
+      "tools_index": []
     }
   },
   "profiles": {

--- a/workflows/data-query.yaml
+++ b/workflows/data-query.yaml
@@ -6,5 +6,6 @@ servers:
 
 text: |
   ### Database Operations
-  WHEN querying, modifying, or analyzing database data:
-  1. Call supabase:query with the appropriate SQL statement
+  The supabase MCP server is disabled by default (not authorized for this
+  deployment). Do not call supabase:query or any supabase:* tool unless a
+  human has explicitly enabled it in mcp-config.json for this environment.

--- a/workflows/proactive-usage.yaml
+++ b/workflows/proactive-usage.yaml
@@ -6,5 +6,4 @@ text: |
   ## Proactive Tool Usage
   WHEN implementing with any library/framework → Lookup docs BEFORE writing code [context7]
   WHEN need current/external information → Search web for up-to-date info [tavily]
-  WHEN database query needed → Query database for data operations [supabase]
   WHEN payment/billing operations → Use Stripe for payment operations [stripe]

--- a/workflows/tool-routing.yaml
+++ b/workflows/tool-routing.yaml
@@ -6,7 +6,7 @@ text: |
   ## Tool Routing Guide
   Use Gateway (airis-exec) for API/service calls. Use host tools for everything else.
 
-  Gateway (airis-exec): library docs → context7 | web search → tavily | database → supabase | payments → stripe | DNS/workers → cloudflare | design files → figma
+  Gateway (airis-exec): library docs → context7 | web search → tavily | payments → stripe | design files → figma
 
   Host tools (NOT Gateway): browser automation → playwright-cli skill (needs host Chrome) | file generation (docx/xlsx/pdf) → claude-api plugin | TDD/debugging/planning → superpowers plugin | git operations → gh CLI or native git | simple code read/edit → native Read/Edit/Grep tools
 


### PR DESCRIPTION
Fixes #193

## What / why

The registry (`mcp-config.json`) and the surfaces that advertise servers (initialize instructions, catalog, toolsets, README, CLAUDE.md) had drifted apart, producing "discoverable but cannot run" (mindbase), "instructed to call a disabled server" (supabase), and "routed to a server that has no usable entry" (cloudflare).

**Root-cause code fix** — discovery now respects `enabled:false`:
- `dynamic_mcp.py` L233: only enabled servers' `tools_index` enter the airis-find cache
- `toolset_catalog.py` L45: disabled servers never populate the toolset index

**Drift content fixes**: cloudflare routing dropped everywhere (registering it needs creds — human decision, out of scope); supabase advertisement removed from `workflows/tool-routing.yaml` / `proactive-usage.yaml` / `data-query.yaml` (these compile into every session's `initialize` instructions), wrong tool names fixed in `docs/architecture.md`; mindbase annotated DISABLED in `catalogs/airis-catalog.yaml`; README "20+ servers / 100+ tools" replaced with registry-accurate wording.

**Note**: this PR edits the repo `CLAUDE.md` (Tool Routing Guide section only) — it carried the same cloudflare/supabase routing drift and is now covered by the gate.

## Acceptance (independently verified)

- Gate RED on pre-fix tree: **10 failures** (cloudflare/supabase/mindbase hits) → GREEN after: 18 passed
- Full unit suite: **406 passed**, exit 0
- `grep cloudflare` across routing surfaces → only the explanatory removal comment
- `grep supabase:query|supabase:execute_sql` → only the explicit "do not call, disabled" caveat
- New `test_disabled_server_is_excluded_from_toolset_index` green

**Gate added/tightened:** `apps/api/tests/unit/test_registry_docs_drift.py` — CI now fails if any routing/instruction surface references a server that doesn't exist or isn't enabled in the registry example (FORBIDDEN set for cloudflare; disabled servers require an explicit disabled-caveat). Plus the runtime enabled-filter has its own unit test.