### PR TITLE
fix: event-driven MCP initialize handshake, no fixed-sleep races (Fixes #194)

### DIFF
--- a/apps/api/src/app/api/endpoints/mcp_proxy.py
+++ b/apps/api/src/app/api/endpoints/mcp_proxy.py
@@ -78,9 +78,36 @@ POOL_TIMEOUT = 10.0
 SSE_KEEPALIVE_INTERVAL = 30.0
 INIT_CLIENT_TIMEOUT = 30.0
 STREAM_BRIDGE_READY_DELAY = 0.3
+# Bounded wait for the Gateway's initialize response to arrive on the
+# session's SSE stream (see _get_initialize_event / issue #194). Generous
+# because it only fires on the misbehaving-client fallback path, not the
+# common case.
+INIT_HANDSHAKE_TIMEOUT = 10.0
 
 # Track initialized sessions for auto-init fallback
 _initialized_sessions: set[str] = set()
+
+# Signaled by proxy_sse_stream() when the Gateway's initialize response
+# arrives for a session (see `is_initialize_response` handling below).
+# Awaited by the auto-init fallback in _proxy_jsonrpc_request() instead of
+# a fixed sleep, since that fallback has no direct visibility into the
+# Gateway's async SSE response (issue #194).
+_session_initialize_events: dict[str, asyncio.Event] = {}
+
+
+def _get_initialize_event(session_id: str) -> asyncio.Event:
+    """Get or create the initialize-response event for a session."""
+    event = _session_initialize_events.get(session_id)
+    if event is None:
+        event = asyncio.Event()
+        _session_initialize_events[session_id] = event
+    return event
+
+
+async def _cleanup_session_state(session_id: str) -> None:
+    """Drop a session's response queue and initialize-wait event together."""
+    await remove_response_queue(session_id)
+    _session_initialize_events.pop(session_id, None)
 
 # SSE stream timeout - long read timeout for long-lived connections
 SSE_TIMEOUT = httpx.Timeout(
@@ -213,7 +240,7 @@ async def proxy_sse_stream(request: Request):
                                 gateway_stream_alive = False
                                 continue
                             if captured_session_id:
-                                await remove_response_queue(captured_session_id)
+                                await _cleanup_session_state(captured_session_id)
                             return
                         except (httpx.ReadError, httpx.RemoteProtocolError, httpx.ConnectError) as e:
                             if task is gateway_task:
@@ -224,7 +251,7 @@ async def proxy_sse_stream(request: Request):
                             # Client disconnected - this is normal, exit gracefully
                             logger.info(f"Client disconnected: {type(e).__name__}")
                             if captured_session_id:
-                                await remove_response_queue(captured_session_id)
+                                await _cleanup_session_state(captured_session_id)
                             return
                         except httpx.ReadTimeout:
                             if task is gateway_task:
@@ -234,7 +261,7 @@ async def proxy_sse_stream(request: Request):
                                 continue
                             logger.info(f"SSE read timeout (session={captured_session_id})")
                             if captured_session_id:
-                                await remove_response_queue(captured_session_id)
+                                await _cleanup_session_state(captured_session_id)
                             return
                         except httpx.TimeoutException as e:
                             if task is gateway_task:
@@ -245,7 +272,7 @@ async def proxy_sse_stream(request: Request):
                             # Other timeout (connect, pool, etc.)
                             logger.info(f"Timeout exception: {type(e).__name__}")
                             if captured_session_id:
-                                await remove_response_queue(captured_session_id)
+                                await _cleanup_session_state(captured_session_id)
                             return
 
                         if source == "tick":
@@ -336,6 +363,13 @@ async def proxy_sse_stream(request: Request):
                                     logger.info(f"Detected initialize response, sending initialized notification to Gateway")
                                     await protocol_logger.log_message("server→client", json_data, {"phase": "initialize"})
 
+                                    # Wake anyone awaiting this session's initialize
+                                    # response (e.g. the auto-init fallback in
+                                    # _proxy_jsonrpc_request()) instead of relying
+                                    # on a fixed sleep budget (issue #194).
+                                    if captured_session_id:
+                                        _get_initialize_event(captured_session_id).set()
+
                                     # POST notifications/initialized to Gateway
                                     initialized_notification = {
                                         "jsonrpc": "2.0",
@@ -374,7 +408,7 @@ async def proxy_sse_stream(request: Request):
                             pass
                 # Cleanup session queue
                 if captured_session_id:
-                    await remove_response_queue(captured_session_id)
+                    await _cleanup_session_state(captured_session_id)
                 logger.info(f"SSE stream cleanup complete (session={captured_session_id})")
 
 
@@ -722,9 +756,18 @@ async def _proxy_jsonrpc_request(request: Request) -> Response:
                 else:
                     logger.info(f"Initialize request accepted: {init_response.status_code}")
 
-                    # Wait for Gateway to process initialize request
-                    # This delay is critical - Gateway needs time to set up session state
-                    await asyncio.sleep(0.15)
+                    # Wait for the Gateway's actual initialize response instead
+                    # of a fixed sleep. proxy_sse_stream() — running concurrently
+                    # on the client's already-open GET /sse for this session —
+                    # sets this event the moment that response arrives (issue #194).
+                    init_event = _get_initialize_event(session_id)
+                    try:
+                        await asyncio.wait_for(init_event.wait(), timeout=INIT_HANDSHAKE_TIMEOUT)
+                    except asyncio.TimeoutError:
+                        logger.warning(
+                            f"Timed out waiting for initialize response for session {session_id}; "
+                            "proceeding with initialized notification anyway"
+                        )
 
                     # Step 2: Send notifications/initialized
                     # Per MCP spec, this should come after initialize response, but in SSE transport
@@ -740,7 +783,13 @@ async def _proxy_jsonrpc_request(request: Request) -> Response:
                     )
 
                     if notif_response.status_code in (200, 202):
-                        # Wait for Gateway to complete initialization before allowing tools/call
+                        # notifications/initialized is a JSON-RPC notification —
+                        # by protocol design it has no response, so there is
+                        # no-observable-event we can await here: the Docker MCP
+                        # Gateway processes it asynchronously after the HTTP
+                        # POST completes (documented upstream limitation, see
+                        # .github/ISSUE_TEMPLATE/mcp-init-race.md). Bounded
+                        # last-resort wait kept per issue #194.
                         await asyncio.sleep(0.10)
                         _initialized_sessions.add(session_id)
                         logger.info(f"Session {session_id} initialized successfully")

--- a/apps/api/src/app/main.py
+++ b/apps/api/src/app/main.py
@@ -105,9 +105,16 @@ async def _precache_docker_gateway_tools():
     endpoint_url = None
     event_type = None
 
+    # Signaled by the outer SSE read loop below when the Gateway's initialize
+    # response (id=1) arrives, so send_requests() can wait for that real
+    # event instead of a fixed sleep (issue #194).
+    init_response_event = asyncio.Event()
+
     async def send_requests(client, endpoint):
         """Send MCP protocol requests."""
-        await asyncio.sleep(0.3)  # Wait for stream to establish
+        # No sleep needed here: `endpoint` is only known once the outer loop
+        # has already received the Gateway's "endpoint" SSE event, which by
+        # construction means the stream is established.
 
         # Initialize
         init_request = {
@@ -125,7 +132,16 @@ async def _precache_docker_gateway_tools():
             json=init_request,
             headers={"Content-Type": "application/json"}
         )
-        await asyncio.sleep(0.2)
+
+        # Wait for the actual initialize response (id=1) on the GET stream,
+        # instead of a fixed sleep that raced under load (issue #194).
+        try:
+            await asyncio.wait_for(init_response_event.wait(), timeout=10.0)
+        except asyncio.TimeoutError:
+            logger.warning(
+                "[Startup] Timed out waiting for initialize response; "
+                "sending initialized notification anyway"
+            )
 
         # Initialized notification
         await client.post(
@@ -133,6 +149,12 @@ async def _precache_docker_gateway_tools():
             json={"jsonrpc": "2.0", "method": "notifications/initialized"},
             headers={"Content-Type": "application/json"}
         )
+        # notifications/initialized has no JSON-RPC response by protocol
+        # design, so there is no-observable-event to await here: the Docker
+        # MCP Gateway processes it asynchronously after the HTTP POST
+        # completes (documented upstream limitation, see
+        # .github/ISSUE_TEMPLATE/mcp-init-race.md). Bounded last-resort wait
+        # kept per issue #194.
         await asyncio.sleep(0.2)
 
         # tools/list
@@ -184,6 +206,10 @@ async def _precache_docker_gateway_tools():
                                     e,
                                     data_str[:200],
                                 )
+                                continue
+
+                            if data.get("id") == 1 and ("result" in data or "error" in data):
+                                init_response_event.set()
                                 continue
 
                             if data.get("id") == 2 and "result" in data:

--- a/apps/api/tests/unit/test_handshake_event_driven.py
+++ b/apps/api/tests/unit/test_handshake_event_driven.py
@@ -1,0 +1,167 @@
+"""
+Regression tests for issue #194: the MCP initialize->initialized auto-init
+fallback in `_proxy_jsonrpc_request()` must wait on the real Gateway
+initialize response instead of racing a fixed sleep budget.
+
+Follows the FakeRequest / monkeypatch pattern from
+test_mcp_proxy_error_injection.py and test_cold_tool_auto_discovery.py.
+"""
+import asyncio
+import json
+import time
+
+import pytest
+
+from app.api.endpoints import mcp_proxy
+from app.core.dynamic_mcp import DynamicMCP
+from app.core.process_manager import ProcessManager
+
+
+class _FakeURL:
+    """Minimal starlette.URL stand-in for _build_gateway_jsonrpc_url()."""
+
+    def __init__(self, path: str = "/v1/mcp/", query: str = ""):
+        self.path = path
+        self.query = query
+
+
+class FakeRequest:
+    """Minimal Starlette-Request stand-in with a sessionid (classic SSE proxy path)."""
+
+    def __init__(self, payload: dict, session_id: str):
+        self._body = json.dumps(payload).encode()
+        self.query_params = {"sessionid": session_id}
+        self.url = _FakeURL()
+        self.headers: dict = {}
+
+    async def body(self) -> bytes:
+        return self._body
+
+
+class FakeResponse:
+    def __init__(self, status_code: int = 202, content: bytes = b"{}"):
+        self.status_code = status_code
+        self.content = content
+        self.headers: dict = {}
+
+
+def _make_fake_async_client(call_log: list):
+    """A minimal httpx.AsyncClient stand-in that records POSTs instead of
+    hitting a real network. Used for both the auto-init handshake's
+    `init_client` and the final passthrough `client` in
+    `_proxy_jsonrpc_request()` — both go through `httpx.AsyncClient(...)`.
+    """
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc_info):
+            return False
+
+        async def post(self, url, **kwargs):
+            call_log.append((time.monotonic(), url, kwargs.get("json")))
+            return FakeResponse()
+
+    return FakeAsyncClient
+
+
+@pytest.fixture
+def wired(monkeypatch):
+    pm = ProcessManager()
+    pm._initialized = True
+    monkeypatch.setattr(mcp_proxy, "get_process_manager", lambda: pm)
+
+    dmcp = DynamicMCP()
+    monkeypatch.setattr(mcp_proxy, "get_dynamic_mcp", lambda: dmcp)
+    return pm, dmcp
+
+
+@pytest.mark.asyncio
+async def test_auto_init_waits_for_slow_initialize_response(wired, monkeypatch):
+    """
+    A slow upstream whose initialize response arrives well after the old
+    fixed 0.15s budget must not be raced past: the handshake has to
+    actually observe the response before sending `notifications/initialized`.
+
+    `proxy_sse_stream()` is the coroutine that normally sets the
+    session's initialize event when the real Gateway response arrives on
+    the client's SSE stream (see `is_initialize_response` handling in
+    mcp_proxy.py). Here we simulate that arriving late, directly via the
+    same `_get_initialize_event()` hook it uses.
+    """
+    session_id = "SESSIONSLOW1"
+    mcp_proxy._initialized_sessions.discard(session_id)
+    mcp_proxy._session_initialize_events.pop(session_id, None)
+
+    call_log: list = []
+    monkeypatch.setattr(mcp_proxy.httpx, "AsyncClient", _make_fake_async_client(call_log))
+
+    slow_delay = 0.5  # far past the old fixed 0.15s + 0.10s budget
+
+    async def deliver_slow_initialize_response():
+        await asyncio.sleep(slow_delay)
+        mcp_proxy._get_initialize_event(session_id).set()
+
+    delivery_task = asyncio.create_task(deliver_slow_initialize_response())
+
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 9,
+        "method": "tools/call",
+        "params": {"name": "some-unregistered-tool", "arguments": {}},
+    }
+
+    start = time.monotonic()
+    resp = await mcp_proxy._proxy_jsonrpc_request(FakeRequest(payload, session_id))
+    elapsed = time.monotonic() - start
+    await delivery_task
+
+    assert resp.status_code == 202
+
+    # The handshake must have actually waited for the (slow) event rather
+    # than racing past it with a fixed sleep budget that would have
+    # completed almost instantly relative to `slow_delay`.
+    assert elapsed >= slow_delay, (
+        f"handshake completed in {elapsed:.3f}s, before the simulated slow "
+        f"initialize response at {slow_delay}s — it raced instead of waiting"
+    )
+    assert session_id in mcp_proxy._initialized_sessions
+
+    # Sanity: both handshake steps were actually sent to the Gateway.
+    methods = [j.get("method") for _, _, j in call_log if j]
+    assert "initialize" in methods
+    assert "notifications/initialized" in methods
+
+
+@pytest.mark.asyncio
+async def test_auto_init_timeout_proceeds_when_initialize_response_never_arrives(
+    wired, monkeypatch
+):
+    """If the initialize event is never signaled (e.g. the Gateway silently
+    drops it), the handshake must still proceed after its bounded timeout
+    rather than hanging forever."""
+    session_id = "SESSIONNEVER1"
+    mcp_proxy._initialized_sessions.discard(session_id)
+    mcp_proxy._session_initialize_events.pop(session_id, None)
+
+    call_log: list = []
+    monkeypatch.setattr(mcp_proxy.httpx, "AsyncClient", _make_fake_async_client(call_log))
+    # Shrink the bounded wait so the test doesn't take 10s.
+    monkeypatch.setattr(mcp_proxy, "INIT_HANDSHAKE_TIMEOUT", 0.2)
+
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 9,
+        "method": "tools/call",
+        "params": {"name": "some-unregistered-tool", "arguments": {}},
+    }
+
+    resp = await mcp_proxy._proxy_jsonrpc_request(FakeRequest(payload, session_id))
+
+    assert resp.status_code == 202
+    # Handshake proceeds best-effort after timing out.
+    assert session_id in mcp_proxy._initialized_sessions

--- a/apps/api/tests/unit/test_no_fixed_sleep_handshake.py
+++ b/apps/api/tests/unit/test_no_fixed_sleep_handshake.py
@@ -1,0 +1,115 @@
+"""
+Gate for issue #194: the MCP initialize->initialized handshake and the
+Docker Gateway pre-cache startup sequence must not rely on fixed wall-clock
+sleeps to paper over races (e.g. "wait 0.15s for the Gateway to process the
+request"). Those budgets are exactly what breaks under load.
+
+This test AST-parses the specific handshake/startup functions and fails if
+any bare `asyncio.sleep(<numeric literal>)` remains in them, with two
+narrow exceptions:
+
+* `asyncio.sleep(0)` — a pure event-loop yield, not a race-driven wait.
+* A sleep whose surrounding comment block contains the literal string
+  "no-observable-event" — a documented last resort for a step that
+  genuinely has no observable completion signal (e.g. a JSON-RPC
+  *notification*, which by protocol has no response to wait on). See
+  .github/ISSUE_TEMPLATE/mcp-init-race.md for the upstream limitation this
+  documents.
+
+Any other fixed sleep in these functions must be replaced with an explicit
+await on the real condition (a queued response, an asyncio.Event, etc.)
+bounded by asyncio.wait_for(..., timeout=...).
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# (file relative to apps/api/src/app, [function names to inspect])
+TARGETS: dict[str, list[str]] = {
+    "src/app/api/endpoints/mcp_proxy.py": ["_proxy_jsonrpc_request"],
+    "src/app/main.py": ["_precache_docker_gateway_tools"],
+}
+
+NO_OBSERVABLE_EVENT_MARKER = "no-observable-event"
+
+
+def _find_named_functions(tree: ast.Module, names: set[str]) -> list[ast.AsyncFunctionDef]:
+    """Find top-level (or nested) function defs matching the given names."""
+    found = []
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name in names:
+            found.append(node)
+    return found
+
+
+def _is_asyncio_sleep_call(node: ast.AST) -> bool:
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    # asyncio.sleep(...)
+    if isinstance(func, ast.Attribute) and func.attr == "sleep":
+        if isinstance(func.value, ast.Name) and func.value.id == "asyncio":
+            return True
+    return False
+
+
+def _numeric_literal(node: ast.AST):
+    if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
+        return node.value
+    return None
+
+
+def _has_marker_nearby(lines: list[str], lineno: int, marker: str, lookback: int = 12) -> bool:
+    """Check the call's own line and up to `lookback` preceding lines for marker."""
+    start = max(0, lineno - 1 - lookback)
+    end = lineno  # lineno is 1-indexed; lines[lineno-1] is the call's own line
+    window = "\n".join(lines[start:end])
+    return marker in window
+
+
+def _violations_in_function(fn: ast.AsyncFunctionDef | ast.FunctionDef, lines: list[str]) -> list[str]:
+    violations = []
+    for node in ast.walk(fn):
+        if not _is_asyncio_sleep_call(node):
+            continue
+        if not node.args:
+            continue
+        value = _numeric_literal(node.args[0])
+        if value is None:
+            # Not a numeric literal (e.g. a variable/backoff expression) —
+            # out of scope for this gate.
+            continue
+        if value == 0:
+            continue
+        if _has_marker_nearby(lines, node.lineno, NO_OBSERVABLE_EVENT_MARKER):
+            continue
+        violations.append(
+            f"{fn.name}() line {node.lineno}: asyncio.sleep({value!r}) is a fixed "
+            "wall-clock wait with no documented no-observable-event justification"
+        )
+    return violations
+
+
+def test_handshake_and_startup_functions_have_no_fixed_sleeps():
+    all_violations: list[str] = []
+
+    for rel_path, fn_names in TARGETS.items():
+        abs_path = REPO_ROOT / rel_path
+        source = abs_path.read_text()
+        lines = source.splitlines()
+        tree = ast.parse(source, filename=str(abs_path))
+
+        matched = _find_named_functions(tree, set(fn_names))
+        found_names = {fn.name for fn in matched}
+        missing = set(fn_names) - found_names
+        assert not missing, f"{rel_path}: expected function(s) not found: {missing}"
+
+        for fn in matched:
+            all_violations.extend(
+                f"{rel_path}: {v}" for v in _violations_in_function(fn, lines)
+            )
+
+    assert not all_violations, "Fixed-sleep handshake races found:\n" + "\n".join(all_violations)


### PR DESCRIPTION
Fixes #194

## What / why

The initialize handshake and startup precache relied on wall-clock sleeps (0.1–0.3s) that race under load — the repo even ships an issue template (`mcp-init-race.md`) for this class. Now:

- **mcp_proxy `_proxy_jsonrpc_request` auto-init**: waits on a per-session `asyncio.Event` set by `proxy_sse_stream` when the Gateway's actual `initialize` response is observed (`INIT_HANDSHAKE_TIMEOUT=10s`, fail-open on expiry as before but correctly bounded). Event is popped at all 5 session-teardown sites — no leak.
- **main.py `_precache_docker_gateway_tools`**: the 0.3s "wait for stream" sleep was provably dead (the `endpoint` SSE event already guarantees establishment) — removed; the post-initialize sleep now awaits the real `id==1` response.
- **2 bounded sleeps remain, by protocol necessity**: `notifications/initialized` is a JSON-RPC notification with no ack; both sites carry a `no-observable-event` comment and the AST gate whitelists exactly that marker.

## Acceptance (independently verified)

- Gate RED on pre-fix code (5 fixed sleeps reported) → GREEN after
- `tests/unit` → **414 passed**, exit 0
- Slow-upstream functional test: handshake waits for a 0.5s-delayed initialize response (would have raced the old 0.15s budget) + timeout-fallback test
- Stash round-trip RED-check re-confirmed by the verifier

**Gate added/tightened:** `test_no_fixed_sleep_handshake.py` — AST-scans the handshake/startup functions and fails if any numeric `asyncio.sleep` reappears without the documented `no-observable-event` last-resort marker.