### PR TITLE
test: eliminate silent-green — COLD startup coverage, strict e2e, skip canary, cov ratchet (Fixes #195)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,11 +97,13 @@ jobs:
 
       - name: Run tests with coverage
         # --cov-fail-under is a regression ratchet, not the end goal. It must
-        # never be lowered — raise it as coverage improves. Target is 70%
-        # (issue #85); bump this number in the same PR that adds the tests.
+        # never be lowered — raise it as coverage improves. Do not chase a
+        # fixed target with filler tests; bump this number in the same PR
+        # that legitimately adds coverage (issue #195: raised from 48 to 52,
+        # actual measured coverage was 54.15% at the time).
         run: |
           cd apps/api
-          python -m pytest tests/unit -v --tb=short --cov=src --cov-report=xml --cov-report=term-missing --cov-fail-under=48
+          python -m pytest tests/unit -v --tb=short --cov=src --cov-report=xml --cov-report=term-missing --cov-fail-under=52
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6

--- a/.tasks.d/test.yml
+++ b/.tasks.d/test.yml
@@ -27,7 +27,14 @@ tasks:
       - docker compose logs api 2>&1 | grep -E "Pre-warm" | tail -10
 
   e2e:
-    desc: Run end-to-end test suite
+    desc: Run end-to-end test suite (against a running `docker compose up -d` stack)
+    # E2E_STRICT=1: the documented e2e entrypoint must be strict. Without it,
+    # tests/e2e/test_mcp_servers_e2e.py silently `pytest.skip()`s on timeouts
+    # instead of failing, so a green `task test:e2e` could mean "everything
+    # timed out" instead of "the stack is healthy" (issue #195). Casual local
+    # runs of `pytest tests/e2e` directly (not through this task) still skip.
+    env:
+      E2E_STRICT: "1"
     cmds:
       - echo "=== Gateway Health ==="
       - task: health
@@ -40,6 +47,9 @@ tasks:
       - echo ""
       - echo "=== Pre-warm Status ==="
       - task: prewarm
+      - echo ""
+      - echo "=== Pytest E2E Suite (strict) ==="
+      - cd apps/api && uv run --extra test python -m pytest tests/e2e -v
       - echo ""
       - echo "✓ All checks passed"
 

--- a/apps/api/tests/e2e/conftest.py
+++ b/apps/api/tests/e2e/conftest.py
@@ -1,0 +1,21 @@
+"""
+Shared helpers for e2e tests (require the live Docker stack).
+"""
+import os
+
+import pytest
+
+
+def skip_or_fail(reason: str) -> None:
+    """Skip a flaky/timeout-prone e2e assertion, unless E2E_STRICT=1.
+
+    Casual local runs (`pytest tests/e2e -v` against a stack that hasn't
+    fully warmed up COLD servers yet) still skip so devs aren't blocked by
+    infra flakiness. The documented e2e entrypoint (`task test:e2e`) sets
+    E2E_STRICT=1 so the same timeouts fail the run instead of silently
+    passing — a green `task test:e2e` should mean the stack is actually
+    healthy, not that everything timed out and skipped (issue #195).
+    """
+    if os.getenv("E2E_STRICT") == "1":
+        pytest.fail(f"[E2E_STRICT] {reason}")
+    pytest.skip(reason)

--- a/apps/api/tests/e2e/test_mcp_servers_e2e.py
+++ b/apps/api/tests/e2e/test_mcp_servers_e2e.py
@@ -18,6 +18,8 @@ import json
 import time
 from typing import Any, Optional
 
+from tests.e2e.conftest import skip_or_fail
+
 # API base URL for E2E tests
 API_BASE_URL = os.getenv("API_BASE_URL", "http://localhost:9400")
 
@@ -88,7 +90,7 @@ class TestGatewayControlServer:
         data = result["data"]
         # May return result or timeout error
         if "error" in data and "timeout" in str(data.get("error", {}).get("message", "")).lower():
-            pytest.skip("Timeout waiting for COLD servers - expected in CI")
+            skip_or_fail("Timeout waiting for COLD servers - expected in CI")
 
         assert "result" in data
         text = data["result"]["content"][0]["text"]
@@ -100,7 +102,7 @@ class TestGatewayControlServer:
             "server_name": "airis-mcp-gateway-control"
         })
         if result.get("timeout"):
-            pytest.skip("Request timed out")
+            skip_or_fail("Request timed out")
         assert result["status_code"] == 200
 
         data = result["data"]
@@ -117,12 +119,12 @@ class TestAirisCommandsServer:
         """airis_config_get should return configuration."""
         result = call_tool(api_client, "airis_config_get", {})
         if result.get("timeout"):
-            pytest.skip("Request timed out")
+            skip_or_fail("Request timed out")
         assert result["status_code"] == 200
 
         data = result["data"]
         if "error" in data and "timeout" in str(data.get("error", {}).get("message", "")).lower():
-            pytest.skip("Timeout - expected in CI")
+            skip_or_fail("Timeout - expected in CI")
 
         assert "result" in data
         # Should return JSON config
@@ -134,12 +136,12 @@ class TestAirisCommandsServer:
         """airis_profile_list should return profiles."""
         result = call_tool(api_client, "airis_profile_list", {})
         if result.get("timeout"):
-            pytest.skip("Request timed out")
+            skip_or_fail("Request timed out")
         assert result["status_code"] == 200
 
         data = result["data"]
         if "error" in data and "timeout" in str(data.get("error", {}).get("message", "")).lower():
-            pytest.skip("Timeout - expected in CI")
+            skip_or_fail("Timeout - expected in CI")
 
         assert "result" in data
 

--- a/apps/api/tests/fixtures/mini_mcp_server.py
+++ b/apps/api/tests/fixtures/mini_mcp_server.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""
+Minimal stdio MCP server used by tests/unit/test_cold_server_startup.py to
+exercise the real COLD-server startup path (spawn -> initialize handshake ->
+tools/list -> tools/call) without depending on any real, external MCP
+server binary.
+
+Speaks newline-delimited JSON-RPC 2.0 on stdin/stdout, matching exactly the
+subset ProcessRunner (src/app/core/process_runner.py) requires:
+  - `initialize`            -> result with serverInfo/capabilities
+  - `notifications/initialized` (notification, no response)
+  - `tools/list`             -> one "echo" tool
+  - `tools/call` name="echo" -> echoes back the given arguments as text
+
+No fixed sleeps — reads and responds to each request as it arrives, so the
+real event-driven handshake in ProcessRunner (issue #194 / PR #202) is
+exercised for real, not simulated.
+"""
+from __future__ import annotations
+
+import json
+import sys
+
+
+def _write(message: dict) -> None:
+    sys.stdout.write(json.dumps(message) + "\n")
+    sys.stdout.flush()
+
+
+def main() -> None:
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+
+        try:
+            request = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        method = request.get("method")
+        request_id = request.get("id")
+
+        if method == "initialize":
+            _write(
+                {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "result": {
+                        "protocolVersion": "2024-11-05",
+                        "capabilities": {"tools": {}},
+                        "serverInfo": {"name": "mini-mcp-server", "version": "0.1.0"},
+                    },
+                }
+            )
+
+        elif method == "notifications/initialized":
+            # Notification — no response expected.
+            continue
+
+        elif method == "tools/list":
+            _write(
+                {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "result": {
+                        "tools": [
+                            {
+                                "name": "echo",
+                                "description": "Echo back the given message argument",
+                                "inputSchema": {
+                                    "type": "object",
+                                    "properties": {"message": {"type": "string"}},
+                                    "required": ["message"],
+                                },
+                            }
+                        ]
+                    },
+                }
+            )
+
+        elif method == "tools/call":
+            params = request.get("params", {})
+            arguments = params.get("arguments", {})
+            if params.get("name") == "echo":
+                _write(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": request_id,
+                        "result": {
+                            "content": [
+                                {
+                                    "type": "text",
+                                    "text": f"echo: {arguments.get('message', '')}",
+                                }
+                            ],
+                            "isError": False,
+                        },
+                    }
+                )
+            else:
+                _write(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": request_id,
+                        "error": {
+                            "code": -32601,
+                            "message": f"Unknown tool: {params.get('name')}",
+                        },
+                    }
+                )
+
+        elif request_id is not None:
+            _write(
+                {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "error": {"code": -32601, "message": f"Method not found: {method}"},
+                }
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/api/tests/unit/test_cold_server_startup.py
+++ b/apps/api/tests/unit/test_cold_server_startup.py
@@ -1,0 +1,136 @@
+"""
+Real COLD-server startup integration test (issue #195).
+
+tests/e2e/test_dynamic_mcp_e2e.py::TestProcessTools::test_list_tools_all_modes
+is permanently `@pytest.mark.skip(reason="COLD server startup takes too long
+for CI")`, so the auto-enable -> spawn -> initialize handshake ->
+tools/call machinery (ProcessManager/ProcessRunner + DynamicMCP's
+auto_discover_and_execute) had zero CI coverage — the most failure-prone
+runtime path in the gateway was untested by every green CI run.
+
+This test drives that path for real (no mocks): it registers a genuine COLD
+server config pointing at tests/fixtures/mini_mcp_server.py (a tiny stdio
+MCP server), then calls the real DynamicMCP.auto_discover_and_execute() and
+asserts the subprocess actually spawned, completed the real event-driven
+MCP handshake (PR #202 — no fixed sleeps), and executed a tool call.
+
+Runs in the `test-python` CI job (tests/unit), no Docker required — the
+"server" is just `python tests/fixtures/mini_mcp_server.py`.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+from app.core.dynamic_mcp import DynamicMCP
+from app.core.mcp_config_loader import McpServerConfig, ServerMode
+from app.core.process_manager import ProcessManager
+from app.core.process_runner import ProcessRunner, ProcessState
+
+FIXTURE_SERVER = Path(__file__).resolve().parents[1] / "fixtures" / "mini_mcp_server.py"
+
+# Generous timeout for the real spawn + handshake; the underlying wait is
+# event-driven (asyncio.Condition, see process_runner.py), not polled, so a
+# healthy run completes in well under a second.
+STARTUP_TIMEOUT = 30.0
+
+
+def _make_cold_config(name: str = "mini-mcp") -> McpServerConfig:
+    assert FIXTURE_SERVER.is_file(), f"mini MCP server fixture missing: {FIXTURE_SERVER}"
+    return McpServerConfig(
+        name=name,
+        server_type="process",
+        command=sys.executable,
+        args=[str(FIXTURE_SERVER)],
+        env={},
+        enabled=False,  # COLD-lazy: not started until auto-enabled
+        mode=ServerMode.COLD,
+        tools_index=[{"name": "echo", "description": "Echo back the given message"}],
+    )
+
+
+def _wire_process_manager(pm: ProcessManager) -> None:
+    """Same wiring as test_cold_tool_auto_discovery.py: expose configs
+    injected directly (bypassing initialize()'s mcp-config.json load)."""
+    pm.get_server_names = lambda: list(pm._server_configs.keys())
+    pm.is_process_server = lambda name: name in pm._runners
+
+
+@pytest_asyncio.fixture
+async def cold_manager():
+    """A ProcessManager wired with one real COLD server (mini_mcp_server.py)."""
+    pm = ProcessManager(idle_timeout=120)
+    pm._initialized = True
+    config = _make_cold_config()
+    pm._server_configs[config.name] = config
+    runner = ProcessRunner(
+        config.to_process_config(pm._idle_timeout),
+        on_idle_kill=pm._handle_idle_kill,
+    )
+    pm._runners[config.name] = runner
+    _wire_process_manager(pm)
+
+    try:
+        yield pm, config.name
+    finally:
+        # Reap the real subprocess regardless of test outcome.
+        await runner.stop()
+
+
+@pytest.mark.asyncio
+async def test_cold_auto_enable_spawns_real_subprocess_and_executes_tool(cold_manager):
+    """End-to-end: auto-discover the COLD tool, auto-enable its server, spawn
+    the real subprocess, complete the real MCP handshake, and call the tool —
+    the exact path the permanently-skipped e2e test was meant to cover."""
+    pm, server_name = cold_manager
+    dmcp = DynamicMCP()
+
+    assert pm._server_configs[server_name].enabled is False, "server must start COLD/disabled"
+
+    result = await asyncio.wait_for(
+        dmcp.auto_discover_and_execute("echo", {"message": "hello"}, pm),
+        timeout=STARTUP_TIMEOUT,
+    )
+
+    assert result is not None, "auto_discover_and_execute returned None — tool/server lookup failed"
+    assert "error" not in result, f"tool call returned an error: {result.get('error')}"
+    assert result["result"]["content"][0]["text"] == "echo: hello"
+
+    # The server must have been genuinely auto-enabled (not just looked up).
+    assert pm._server_configs[server_name].enabled is True
+
+    # Prove a real subprocess was spawned and completed the real handshake —
+    # not a stub/mocked response.
+    runner = pm.get_runner(server_name)
+    assert runner.state == ProcessState.READY
+    assert runner._proc is not None
+    assert runner._proc.pid is not None
+    assert runner._proc.returncode is None, "subprocess exited instead of staying up"
+    assert any(t.get("name") == "echo" for t in runner.tools), "tools/list did not return the echo tool"
+
+
+@pytest.mark.asyncio
+async def test_cold_server_already_enabled_reuses_running_process(cold_manager):
+    """Calling twice must not re-spawn a second subprocess for the same server."""
+    pm, server_name = cold_manager
+    dmcp = DynamicMCP()
+
+    first = await asyncio.wait_for(
+        dmcp.auto_discover_and_execute("echo", {"message": "one"}, pm),
+        timeout=STARTUP_TIMEOUT,
+    )
+    runner = pm.get_runner(server_name)
+    first_pid = runner._proc.pid
+
+    second = await asyncio.wait_for(
+        dmcp.auto_discover_and_execute("echo", {"message": "two"}, pm),
+        timeout=STARTUP_TIMEOUT,
+    )
+
+    assert first["result"]["content"][0]["text"] == "echo: one"
+    assert second["result"]["content"][0]["text"] == "echo: two"
+    assert runner._proc.pid == first_pid, "second call spawned a new subprocess instead of reusing it"

--- a/apps/api/tests/unit/test_dockerfile_cache_mounts.py
+++ b/apps/api/tests/unit/test_dockerfile_cache_mounts.py
@@ -27,13 +27,18 @@ TS_APPS = ["gateway-control", "airis-commands"]
 
 # CI runs pytest from a full repo checkout; inside the api container only
 # apps/api/src is available, so the Dockerfile path does not resolve. Skip
-# the module so the Docker-internal smoke run stays green; CI is the
+# the module there so the Docker-internal smoke run stays green; CI is the
 # authoritative gate.
-if not DOCKERFILE.exists():
+#
+# The skip condition checks `.git` (an environment signal independent of the
+# guarded file), NOT `DOCKERFILE.exists()` itself. If it checked the guarded
+# file directly, a real regression (Dockerfile deleted/moved in a full
+# checkout) would silently skip instead of failing (issue #195).
+if not (REPO_ROOT / ".git").exists():
     pytest.skip(
-        f"Dockerfile not reachable from {DOCKERFILE} — likely running inside "
-        "the api container, skipping. CI on a full repo checkout provides "
-        "the real gate.",
+        f"{REPO_ROOT} is not a full repo checkout (no .git) — likely running "
+        "inside the api container, skipping. CI on a full repo checkout "
+        "provides the real gate.",
         allow_module_level=True,
     )
 

--- a/apps/api/tests/unit/test_dockerignore_regression.py
+++ b/apps/api/tests/unit/test_dockerignore_regression.py
@@ -19,10 +19,16 @@ DOCKERIGNORE = REPO_ROOT / ".dockerignore"
 
 # CI runs pytest from a full repo checkout, so .dockerignore is reachable.
 # Inside the api container the repo is not mounted (only apps/api is COPYed),
-# so these tests must skip — the CI run is the authoritative gate.
-if not DOCKERIGNORE.exists():
+# so these tests must skip there — the CI run is the authoritative gate.
+#
+# The skip condition checks `.git` (an environment signal independent of the
+# guarded file), NOT `.dockerignore.exists()` itself. If it checked the
+# guarded file directly, a real regression (someone deletes .dockerignore in
+# a full checkout) would silently skip instead of failing — the guard must
+# fail loudly whenever it can positively see the repo root (issue #195).
+if not (REPO_ROOT / ".git").exists():
     pytest.skip(
-        f".dockerignore not reachable from {DOCKERIGNORE} — likely running "
+        f"{REPO_ROOT} is not a full repo checkout (no .git) — likely running "
         "inside the api container, skipping. CI on a full repo checkout "
         "provides the real gate.",
         allow_module_level=True,

--- a/apps/api/tests/unit/test_no_silent_skip_guards.py
+++ b/apps/api/tests/unit/test_no_silent_skip_guards.py
@@ -1,0 +1,123 @@
+"""
+AST guard: forbid the "skip when guarded file is missing" anti-pattern in
+tests/unit/ (issue #195).
+
+A guard test that does:
+    if not <guarded_artifact>.exists():
+        pytest.skip(...)
+silently downgrades a real regression (the guarded file was deleted or
+moved) into a green skip instead of a failure — exactly the "silent green"
+this issue exists to eliminate.
+
+The one legitimate shape is checking an *environment* signal that is
+independent of the artifact under test: this repo's convention is `.git`
+absence, meaning "not a full checkout" (e.g. `docker compose exec api
+pytest tests/ -v`, where only apps/api/src is COPYed into the image, so
+repo-root paths like the Dockerfile or .dockerignore never resolve). See
+tests/unit/test_uv_lock_tracked.py, test_dockerignore_regression.py,
+test_dockerfile_cache_mounts.py, test_package_manager_consistency.py, and
+test_typescript_no_unsafe_cast.py for the sanctioned pattern.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+UNIT_DIR = Path(__file__).resolve().parent
+THIS_FILE = Path(__file__).resolve()
+
+# Substrings that, if present in the unparsed `.exists()`-checked expression,
+# mark the skip as a legitimate environment-signal check rather than a
+# guarded-artifact check.
+ALLOWED_SIGNAL_MARKERS = (".git",)
+
+
+def _is_exists_check(node: ast.expr) -> bool:
+    """`X.exists()`."""
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "exists"
+    )
+
+
+def _is_all_exists_check(node: ast.expr) -> bool:
+    """`all(p.exists() for p in XS)`."""
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "all"
+    )
+
+
+def _contains_skip_call(body: list[ast.stmt]) -> bool:
+    for stmt in body:
+        for n in ast.walk(stmt):
+            if (
+                isinstance(n, ast.Call)
+                and isinstance(n.func, ast.Attribute)
+                and n.func.attr == "skip"
+            ):
+                return True
+    return False
+
+
+def _iter_exists_skip_guards(tree: ast.Module):
+    """Yield (lineno, condition_source) for every `if not <exists check>:
+    ... pytest.skip(...)` node found anywhere in the module."""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+        test = node.test
+        if not (isinstance(test, ast.UnaryOp) and isinstance(test.op, ast.Not)):
+            continue
+        operand = test.operand
+        if not (_is_exists_check(operand) or _is_all_exists_check(operand)):
+            continue
+        if not _contains_skip_call(node.body):
+            continue
+        yield node.lineno, ast.unparse(test)
+
+
+def _unit_test_files() -> list[Path]:
+    return sorted(p for p in UNIT_DIR.glob("*.py") if p.resolve() != THIS_FILE)
+
+
+@pytest.mark.parametrize("path", _unit_test_files(), ids=lambda p: p.name)
+def test_no_file_not_found_skip_guards(path: Path):
+    """Every `if not X.exists(): pytest.skip(...)` in tests/unit/ must check
+    an environment signal (e.g. `.git` absence), never the guarded
+    artifact's own existence — otherwise a real regression (the file was
+    deleted/moved) silently skips the guard instead of failing it."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+    for lineno, condition_src in _iter_exists_skip_guards(tree):
+        assert any(marker in condition_src for marker in ALLOWED_SIGNAL_MARKERS), (
+            f"{path.name}:{lineno} skips on `{condition_src}` — this checks "
+            "the guarded artifact's own existence, so deleting/moving it "
+            "would silently skip the guard instead of failing it. Use an "
+            "environment signal (e.g. `.git` absence, matching the pattern "
+            "in test_uv_lock_tracked.py) instead, and let the individual "
+            "test functions assert the artifact exists (issue #195)."
+        )
+
+
+def test_guard_actually_detects_the_forbidden_pattern():
+    """Meta-test: prove the AST scan fires on the exact anti-pattern it
+    exists to forbid, so a broken detector can't silently pass everything."""
+    src = (
+        "from pathlib import Path\n"
+        "import pytest\n"
+        "TARGET = Path('/nonexistent/guarded-file.txt')\n"
+        "if not TARGET.exists():\n"
+        "    pytest.skip('missing', allow_module_level=True)\n"
+    )
+    tree = ast.parse(src, filename="<forbidden-pattern-fixture>")
+    matches = list(_iter_exists_skip_guards(tree))
+    assert matches, "detector failed to find the forbidden exists()-skip pattern"
+    assert not any(
+        any(marker in cond for marker in ALLOWED_SIGNAL_MARKERS)
+        for _, cond in matches
+    ), "fixture condition unexpectedly matched the allowlist"

--- a/apps/api/tests/unit/test_no_silent_skip_guards.py
+++ b/apps/api/tests/unit/test_no_silent_skip_guards.py
@@ -31,7 +31,9 @@ THIS_FILE = Path(__file__).resolve()
 # Substrings that, if present in the unparsed `.exists()`-checked expression,
 # mark the skip as a legitimate environment-signal check rather than a
 # guarded-artifact check.
-ALLOWED_SIGNAL_MARKERS = (".git",)
+# Quoted literals so `.github`/`.gitignore` (guarded artifacts, not
+# environment signals) can never substring-match the allowlist.
+ALLOWED_SIGNAL_MARKERS = ('".git"', "'.git'")
 
 
 def _is_exists_check(node: ast.expr) -> bool:

--- a/apps/api/tests/unit/test_package_manager_consistency.py
+++ b/apps/api/tests/unit/test_package_manager_consistency.py
@@ -27,10 +27,16 @@ TS_APPS = ["gateway-control", "airis-commands"]
 # CI runs pytest from a full repo checkout; inside the api container only
 # apps/api/src is available, so repo paths do not resolve. Skip the module
 # there so the Docker-internal smoke run stays green — CI is the real gate.
-if not DOCKERFILE.exists():
+#
+# The skip condition checks `.git` (an environment signal independent of the
+# guarded files), NOT `DOCKERFILE.exists()` itself. If it checked a guarded
+# file directly, a real regression (Dockerfile/lockfile deleted or moved in a
+# full checkout) would silently skip instead of failing (issue #195).
+if not (REPO_ROOT / ".git").exists():
     pytest.skip(
-        f"repo not fully reachable from {DOCKERFILE} — likely running inside "
-        "the api container, skipping. CI on a full repo checkout is the gate.",
+        f"{REPO_ROOT} is not a full repo checkout (no .git) — likely running "
+        "inside the api container, skipping. CI on a full repo checkout is "
+        "the gate.",
         allow_module_level=True,
     )
 

--- a/apps/api/tests/unit/test_typescript_no_unsafe_cast.py
+++ b/apps/api/tests/unit/test_typescript_no_unsafe_cast.py
@@ -31,7 +31,12 @@ TS_APPS = [
 # Inside the api container only apps/api is COPYed, so the TS sources are
 # unreachable. CI checks out the full repo, where these paths resolve; that
 # is the authoritative gate.
-if not all(p.exists() for p in TS_APPS):
+#
+# The skip condition checks `.git` (an environment signal independent of the
+# guarded files), NOT the TS_APPS paths themselves. If it checked the
+# guarded files directly, a real regression (a TS app moved/deleted in a
+# full checkout) would silently skip instead of failing (issue #195).
+if not (REPO_ROOT / ".git").exists():
     pytest.skip(
         "TypeScript app sources not reachable — likely running inside the "
         "api container, skipping. CI on a full repo checkout provides the "


### PR DESCRIPTION
Fixes #195

## What / why

Green CI didn't mean the runtime paths work:

- **COLD startup had zero CI coverage** (permanent e2e skip). New `test_cold_server_startup.py` drives the REAL ProcessRunner/ProcessManager against an in-repo stdio MCP server (`tests/fixtures/mini_mcp_server.py`): real subprocess PID, event-driven handshake, tools/list + tools/call round trip, PID reuse on second call. Runs in the normal `test-python` CI job, no Docker.
- **Bonus finding**: `task test:e2e` never actually invoked `pytest tests/e2e` — it only ran curl smoke checks. Now it runs the suite with `E2E_STRICT=1`, under which the 6 "Timeout - expected in CI" skips become failures (default non-strict behavior unchanged for casual local runs).
- **4 guard tests** (dockerignore/cache-mounts/package-manager/unsafe-cast) no longer silently no-op when their guarded file moves — file-gone now fails; only the legitimate in-container (.git-absent) environment skip remains.
- **Coverage ratchet**: floor 48 → **52** (measured actual 54.15%; ratchet = actual−2, strengthen-only).

## Acceptance (independently verified)

- `tests/unit` → **470 passed**, exit 0
- COLD startup test: real subprocess asserted (PID, returncode None, echo tool round-trip) — 2 passed
- `--cov-fail-under=52` → "Required test coverage of 52% reached. Total coverage: 54.15%"
- RED-check: reintroducing a file-not-found skip guard makes `test_no_silent_skip_guards.py` fail (verified, then restored)

**Gate added/tightened:** COLD-startup integration test + `test_no_silent_skip_guards.py` AST canary + coverage floor 48→52 + `E2E_STRICT=1` wired into the documented e2e entrypoint.