### PR TITLE
feat: per-server health surfacing in find/exec/health endpoint (Fixes #197)

### DIFF
--- a/apps/api/src/app/api/endpoints/mcp_proxy.py
+++ b/apps/api/src/app/api/endpoints/mcp_proxy.py
@@ -1216,7 +1216,7 @@ async def handle_airis_find(rpc_request: Dict[str, Any], session_id: Optional[st
                 dynamic_mcp._servers[server].tools_count = len(server_tools)
             logger.info(f"Loaded {len(server_tools)} tools from '{server}'")
 
-    results = dynamic_mcp.find(query=query, server=server)
+    results = dynamic_mcp.find(query=query, server=server, process_manager=process_manager)
 
     # Format results as text for LLM consumption
     lines = []
@@ -1238,7 +1238,10 @@ async def handle_airis_find(rpc_request: Dict[str, Any], session_id: Optional[st
     if results['tools']:
         lines.append("## Tools")
         for t in results['tools']:
-            lines.append(f"- **{t['server']}:{t['name']}** - {t['description']}")
+            line = f"- **{t['server']}:{t['name']}** - {t['description']}"
+            if t.get("server_status"):
+                line += f" [⚠ {t['server_status']}: {t.get('server_error', 'no details')}]"
+            lines.append(line)
 
     if not results['tools'] and not results['servers'] and not results.get('toolsets'):
         lines.append("No matches found. Try a different query or use airis-find without arguments to list all.")
@@ -1373,6 +1376,17 @@ async def handle_airis_exec(rpc_request: Dict[str, Any], session_id: Optional[st
             inner_error = result.get("error") if isinstance(result, dict) else None
             if inner_error is not None:
                 error_msg = inner_error.get("message", "")
+                # Enrich with the recorded health cause when the server itself
+                # couldn't be reached (e.g. missing API key, dead command),
+                # instead of surfacing a bare "failed to initialize".
+                health = process_manager.get_server_health(server_name)
+                if health.status in ("start_failed", "list_failed") and health.last_error:
+                    error_msg = (
+                        f"{error_msg}\n\nServer '{server_name}' health: {health.status} "
+                        f"— {health.last_error}\nHint: check the server's command/env "
+                        f"configuration in mcp-config.json."
+                    )
+                    inner_error["message"] = error_msg
                 # Attach schema hint so LLM can retry with correct arguments
                 schema_hint = None
                 tool_info = dynamic_mcp._tools.get(tool_name)

--- a/apps/api/src/app/core/dynamic_mcp.py
+++ b/apps/api/src/app/core/dynamic_mcp.py
@@ -103,6 +103,7 @@ class DynamicMCP:
                         new_tool_to_server[tool_name] = name
             except Exception as e:
                 logger.error(f"Failed to cache tools for {name}: {e}")
+                process_manager.record_health(name, "list_failed", str(e))
 
         # Cache Docker MCP Gateway tools
         docker_server_tools: dict[str, int] = {}  # server_name -> tools_count
@@ -195,6 +196,7 @@ class DynamicMCP:
                             new_tool_to_server[tool_name] = name
                 except Exception as e:
                     logger.error(f"Failed to cache HOT tools for {name}: {e}")
+                    process_manager.record_health(name, "list_failed", str(e))
 
         # Cache Docker MCP Gateway tools
         docker_server_tools: dict[str, int] = {}
@@ -375,6 +377,7 @@ class DynamicMCP:
             return tools
         except Exception as e:
             logger.error(f"Failed to load tools from {server_name}: {e}")
+            process_manager.record_health(server_name, "list_failed", str(e))
             return []
 
     def _infer_server_name(self, tool_name: str) -> str:
@@ -405,7 +408,8 @@ class DynamicMCP:
         self,
         query: Optional[str] = None,
         server: Optional[str] = None,
-        limit: int = 20
+        limit: int = 20,
+        process_manager=None,
     ) -> dict[str, Any]:
         """
         Search for tools and servers.
@@ -414,6 +418,10 @@ class DynamicMCP:
             query: Search query (matches tool name, description, server name)
             server: Filter by server name
             limit: Max results to return
+            process_manager: If given, matched tools whose server is in a
+                failure health state get a "server_status"/"server_error"
+                annotation so the caller sees "found but currently broken"
+                instead of the tool silently vanishing.
 
         Returns:
             Dict with matched servers and tools
@@ -492,11 +500,18 @@ class DynamicMCP:
                 if not (substring_match or keyword_match):
                     continue
 
-            matched_tools.append({
+            tool_result = {
                 "name": info.name,
                 "server": info.server,
                 "description": self._truncate(info.description, 100),
-            })
+            }
+            if process_manager is not None:
+                health = process_manager.get_server_health(info.server)
+                if health.status not in ("ok", "not_started"):
+                    tool_result["server_status"] = health.status
+                    if health.last_error:
+                        tool_result["server_error"] = self._truncate(health.last_error, 200)
+            matched_tools.append(tool_result)
 
             if len(matched_tools) >= limit:
                 break

--- a/apps/api/src/app/core/process_manager.py
+++ b/apps/api/src/app/core/process_manager.py
@@ -10,6 +10,8 @@ Provides:
 """
 
 import asyncio
+import time
+from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Optional
 
 from .process_runner import ProcessRunner, ProcessConfig, ProcessState
@@ -32,6 +34,22 @@ STATE_CHANGE_DISABLED = "disabled"
 STATE_CHANGE_IDLE_KILLED = "idle_killed"
 
 StateChangeListener = Callable[[str, str], Awaitable[None]]
+
+# Stored error strings are truncated to this length to avoid unbounded
+# memory growth if an upstream server repeatedly fails with a large payload.
+_HEALTH_ERROR_MAX_LEN = 300
+
+
+@dataclass
+class ServerHealth:
+    """Per-server health record surfaced via /health/servers and airis-find.
+
+    status: "ok" | "start_failed" | "list_failed" | "policy_disabled" |
+            "disabled" | "not_started"
+    """
+    status: str = "not_started"
+    last_error: Optional[str] = None
+    last_checked: Optional[float] = None
 
 
 class ProcessManager:
@@ -60,6 +78,7 @@ class ProcessManager:
         self._tool_to_server: dict[str, str] = {}  # tool_name -> server_name
         self._prompt_to_server: dict[str, str] = {}  # prompt_name -> server_name
         self._server_locks: dict[str, asyncio.Lock] = {}  # per-server locks
+        self._health: dict[str, ServerHealth] = {}  # server_name -> ServerHealth
         self._initialized = False
         # Listeners for HOT-set membership changes. Invoked whenever a server
         # is enabled, disabled, or idle-killed so the proxy layer can emit
@@ -84,6 +103,27 @@ class ProcessManager:
                     f"state-change listener failed ({event} on {server_name}): {exc}"
                 )
 
+    def record_health(self, name: str, status: str, error: Optional[str] = None) -> None:
+        """Record a server's health status.
+
+        Called wherever an upstream failure (or its recovery) is observed —
+        start failures, tool-listing exceptions, policy/enable state changes.
+        Error text is truncated to avoid unbounded memory from repeated
+        large failure payloads.
+        """
+        truncated = error[:_HEALTH_ERROR_MAX_LEN] if error else None
+        self._health[name] = ServerHealth(
+            status=status, last_error=truncated, last_checked=time.time()
+        )
+
+    def get_server_health(self, name: str) -> ServerHealth:
+        """Get the health record for a server (defaults to not_started)."""
+        return self._health.get(name, ServerHealth())
+
+    def get_all_health(self) -> dict[str, ServerHealth]:
+        """Get the full per-server health map."""
+        return dict(self._health)
+
     async def initialize(self):
         """Load config and prepare runners (but don't start processes yet)."""
         if self._initialized:
@@ -101,6 +141,9 @@ class ProcessManager:
                 on_idle_kill=self._handle_idle_kill,
             )
             self._runners[name] = runner
+
+            if getattr(server_config, "policy_disabled", False):
+                self.record_health(name, "policy_disabled")
 
             logger.info(f"Registered server: {name} (enabled={server_config.enabled})")
 
@@ -207,6 +250,10 @@ class ProcessManager:
         self._server_configs[name].enabled = True
         logger.info(f"Enabled server: {name}")
         if not already_enabled:
+            # A server just re-enabled from "disabled" gets a clean slate —
+            # the next listing attempt will re-establish real health.
+            if self._health.get(name, ServerHealth()).status == "disabled":
+                self.record_health(name, "not_started")
             await self._fire_state_change(STATE_CHANGE_ENABLED, name)
         return True
 
@@ -229,6 +276,7 @@ class ProcessManager:
         }
 
         logger.info(f"Disabled server: {name}")
+        self.record_health(name, "disabled")
         if was_enabled:
             await self._fire_state_change(STATE_CHANGE_DISABLED, name)
         return True
@@ -304,6 +352,7 @@ class ProcessManager:
             success, error = await runner.ensure_ready_with_error()
             if not success:
                 logger.error(f"Failed to start server: {name} - {error or 'Unknown error'}")
+                self.record_health(name, "start_failed", error)
                 return []
 
             # Cache tool -> server mapping
@@ -312,6 +361,7 @@ class ProcessManager:
                 if tool_name:
                     self._tool_to_server[tool_name] = name
 
+            self.record_health(name, "ok")
             return runner.tools
 
     def list_cached_tools(self, mode: Optional[str] = None) -> list[dict[str, Any]]:
@@ -532,7 +582,17 @@ class ProcessManager:
                 }
             }
 
-        return await runner.call_tool(tool_name, arguments)
+        result = await runner.call_tool(tool_name, arguments)
+
+        # A call failure while the process never reached READY is a start
+        # failure, not a business error from the remote tool — record it so
+        # airis-exec can enrich the JSON-RPC error with the real cause.
+        if isinstance(result, dict) and result.get("error") and runner.state != ProcessState.READY:
+            self.record_health(server_name, "start_failed", runner._last_error)
+        elif isinstance(result, dict) and not result.get("error"):
+            self.record_health(server_name, "ok")
+
+        return result
 
     async def send_request(
         self,

--- a/apps/api/src/app/core/process_manager.py
+++ b/apps/api/src/app/core/process_manager.py
@@ -201,6 +201,7 @@ class ProcessManager:
 
                 success, error = await runner.ensure_ready_with_error()
                 if success:
+                    self.record_health(name, "ok")
                     # Cache tool -> server mapping
                     for tool in runner.tools:
                         tool_name = tool.get("name", "")
@@ -208,6 +209,7 @@ class ProcessManager:
                             self._tool_to_server[tool_name] = name
                     logger.info(f"Pre-warmed {name}: {len(runner.tools)} tools")
                 else:
+                    self.record_health(name, "start_failed", error or "Unknown error")
                     logger.warning(f"Failed to pre-warm {name}: {error or 'Unknown error'}")
                 return (name, success)
             except Exception as e:
@@ -441,8 +443,10 @@ class ProcessManager:
         # Ensure process is running and initialized
         success, error = await runner.ensure_ready_with_error()
         if not success:
+            self.record_health(name, "start_failed", error or "Unknown error")
             logger.error(f"Failed to start server: {name} - {error or 'Unknown error'}")
             return []
+        self.record_health(name, "ok")
 
         # Cache prompt -> server mapping
         for prompt in runner.prompts:

--- a/apps/api/src/app/main.py
+++ b/apps/api/src/app/main.py
@@ -517,6 +517,32 @@ async def health():
     return {"status": "healthy"}
 
 
+@app.get("/health/servers")
+async def health_servers():
+    """
+    Per-server health map — surfaces upstream failures that otherwise only
+    show up as a log line while the server silently vanishes from
+    tools/list / airis-find (issue #197).
+
+    Read-only, no auth change (matches /health, /ready — localhost-only gateway).
+    """
+    manager = get_process_manager()
+    servers = {}
+    for name in manager.get_server_names():
+        config = manager._server_configs.get(name)
+        health_record = manager.get_server_health(name)
+        servers[name] = {
+            "name": name,
+            "mode": config.mode.value if config else None,
+            "enabled": config.enabled if config else False,
+            "policy_disabled": getattr(config, "policy_disabled", False) if config else False,
+            "status": health_record.status,
+            "last_error": health_record.last_error,
+            "last_checked": health_record.last_checked,
+        }
+    return {"servers": servers}
+
+
 @app.get("/ready")
 async def ready():
     """

--- a/apps/api/tests/unit/test_server_health_surfacing.py
+++ b/apps/api/tests/unit/test_server_health_surfacing.py
@@ -1,0 +1,264 @@
+"""
+Tests for per-server health surfacing (issue #197).
+
+Today, upstream server failures (missing API key, dead command, exception
+during tool listing) are swallowed by broad `except Exception: log &
+continue` sites in `dynamic_mcp.py` / `process_manager.py`. A misconfigured
+server just disappears from `tools/list` / `airis-find` with only a log
+line — the LLM sees "some tools are missing" with no cause.
+
+These tests pin the fix: a per-server `ServerHealth` record on
+`ProcessManager`, surfaced via `DynamicMCP.find()` annotations and a new
+`GET /health/servers` endpoint, with `airis-exec` error enrichment.
+"""
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core.dynamic_mcp import DynamicMCP, ToolInfo
+from app.core.mcp_config_loader import McpServerConfig, ServerMode
+from app.core.process_manager import ProcessManager, ServerHealth
+from app.core.process_runner import ProcessState
+
+
+# ── Helpers ──
+
+
+def _make_config(name: str, *, enabled: bool = True, mode=ServerMode.COLD,
+                  policy_disabled: bool = False) -> McpServerConfig:
+    return McpServerConfig(
+        name=name,
+        server_type="process",
+        command="uvx",
+        args=["test-server"],
+        env={},
+        enabled=enabled,
+        policy_disabled=policy_disabled,
+        mode=mode,
+        tools_index=[],
+    )
+
+
+class _FakeRunner:
+    """Minimal ProcessRunner stand-in whose first ensure_ready_with_error()
+    call fails (simulating a dead command / missing env var), then
+    succeeds on the next call (simulating the operator fixing the config)."""
+
+    def __init__(self, error_message: str = "missing API key: STRIPE_KEY not set"):
+        self.state = ProcessState.STOPPED
+        self.tools = [{"name": "create_customer", "description": "Create a customer"}]
+        self._error_message = error_message
+        self._attempts = 0
+
+    async def ensure_ready_with_error(self, timeout: float = 30.0):
+        self._attempts += 1
+        if self._attempts == 1:
+            self.state = ProcessState.STOPPED
+            return (False, self._error_message)
+        self.state = ProcessState.READY
+        return (True, None)
+
+
+# ── ProcessManager: health recording on start failure / recovery ──
+
+
+@pytest.mark.asyncio
+async def test_start_failure_records_health_with_error():
+    pm = ProcessManager()
+    pm._initialized = True
+    pm._server_configs["stripe"] = _make_config("stripe")
+    pm._runners["stripe"] = _FakeRunner()
+
+    tools = await pm._list_tools_for_server("stripe")
+
+    assert tools == []
+    health = pm.get_server_health("stripe")
+    assert health.status == "start_failed"
+    assert health.last_error is not None
+    assert "missing API key" in health.last_error
+    assert health.last_checked is not None
+
+
+@pytest.mark.asyncio
+async def test_subsequent_success_resets_health_to_ok():
+    """A server that fails once and then starts cleanly must not stay
+    flagged as broken forever — this is the isolation guarantee: one bad
+    attempt must not permanently poison discovery once fixed."""
+    pm = ProcessManager()
+    pm._initialized = True
+    pm._server_configs["stripe"] = _make_config("stripe")
+    runner = _FakeRunner()
+    pm._runners["stripe"] = runner
+
+    await pm._list_tools_for_server("stripe")  # fails
+    assert pm.get_server_health("stripe").status == "start_failed"
+
+    tools = await pm._list_tools_for_server("stripe")  # now succeeds
+
+    assert len(tools) == 1
+    health = pm.get_server_health("stripe")
+    assert health.status == "ok"
+    assert health.last_error is None
+
+
+def test_error_text_truncated_to_avoid_unbounded_memory():
+    pm = ProcessManager()
+    pm.record_health("stripe", "start_failed", "x" * 5000)
+
+    health = pm.get_server_health("stripe")
+    assert len(health.last_error) <= 300
+
+
+def test_unrecorded_server_defaults_to_not_started():
+    pm = ProcessManager()
+    health = pm.get_server_health("never-touched")
+    assert health.status == "not_started"
+    assert health.last_error is None
+
+
+# ── DynamicMCP.find(): silent-vanish regression guard ──
+
+
+def test_airis_find_annotates_tools_for_failing_server():
+    """The core regression guard: a server's indexed tools stay discoverable
+    (they don't vanish) AND carry a server_status/server_error annotation
+    once its health record shows a failure — instead of looking identical
+    to a healthy server's tools."""
+    dmcp = DynamicMCP()
+    dmcp._tools["create_customer"] = ToolInfo(
+        name="create_customer",
+        server="stripe",
+        description="Create a Stripe customer",
+        input_schema={},
+        source="index",
+    )
+    dmcp._tool_to_server["create_customer"] = "stripe"
+
+    pm = ProcessManager()
+    pm.record_health("stripe", "start_failed", "missing API key: STRIPE_KEY not set")
+
+    results = dmcp.find(query="stripe", process_manager=pm)
+
+    matches = [t for t in results["tools"] if t["name"] == "create_customer"]
+    assert matches, "tool must still be discoverable, not silently vanish"
+    entry = matches[0]
+    assert entry["server_status"] == "start_failed"
+    assert "missing API key" in entry["server_error"]
+
+
+def test_airis_find_does_not_annotate_healthy_server():
+    dmcp = DynamicMCP()
+    dmcp._tools["create_customer"] = ToolInfo(
+        name="create_customer",
+        server="stripe",
+        description="Create a Stripe customer",
+        input_schema={},
+        source="index",
+    )
+    dmcp._tool_to_server["create_customer"] = "stripe"
+
+    pm = ProcessManager()
+    pm.record_health("stripe", "ok")
+
+    results = dmcp.find(query="stripe", process_manager=pm)
+
+    entry = [t for t in results["tools"] if t["name"] == "create_customer"][0]
+    assert "server_status" not in entry
+    assert "server_error" not in entry
+
+
+def test_airis_find_without_process_manager_is_unannotated_backward_compat():
+    """find() without process_manager (existing callers) behaves exactly
+    as before — no annotation keys added."""
+    dmcp = DynamicMCP()
+    dmcp._tools["create_customer"] = ToolInfo(
+        name="create_customer", server="stripe", description="Create customer",
+        input_schema={}, source="index",
+    )
+    dmcp._tool_to_server["create_customer"] = "stripe"
+
+    results = dmcp.find(query="stripe")
+
+    entry = results["tools"][0]
+    assert "server_status" not in entry
+
+
+# ── GET /health/servers ──
+
+
+def test_health_servers_endpoint_returns_map(monkeypatch):
+    from app.main import app
+
+    pm = ProcessManager()
+    pm._initialized = True
+    pm._server_configs["stripe"] = _make_config("stripe", mode=ServerMode.COLD, enabled=False)
+    pm._runners["stripe"] = _FakeRunner()
+    pm.record_health("stripe", "start_failed", "boom")
+
+    monkeypatch.setattr("app.main.get_process_manager", lambda: pm)
+
+    client = TestClient(app)
+    resp = client.get("/health/servers")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "stripe" in body["servers"]
+    entry = body["servers"]["stripe"]
+    assert entry["status"] == "start_failed"
+    assert entry["last_error"] == "boom"
+    assert entry["mode"] == "cold"
+    assert entry["enabled"] is False
+    assert entry["policy_disabled"] is False
+    assert entry["last_checked"] is not None
+
+
+def test_health_servers_endpoint_reports_policy_disabled(monkeypatch):
+    from app.main import app
+
+    pm = ProcessManager()
+    pm._initialized = True
+    pm._server_configs["supabase"] = _make_config(
+        "supabase", mode=ServerMode.COLD, enabled=False, policy_disabled=True
+    )
+    pm._runners["supabase"] = _FakeRunner()
+    pm.record_health("supabase", "policy_disabled")
+
+    monkeypatch.setattr("app.main.get_process_manager", lambda: pm)
+
+    client = TestClient(app)
+    resp = client.get("/health/servers")
+
+    entry = resp.json()["servers"]["supabase"]
+    assert entry["policy_disabled"] is True
+    assert entry["status"] == "policy_disabled"
+
+
+# ── ProcessManager.call_tool_on_server: enrichment source ──
+
+
+@pytest.mark.asyncio
+async def test_call_tool_on_server_records_start_failure_health():
+    """airis-exec calls call_tool_on_server directly (bypassing
+    _list_tools_for_server). This must also record health so the JSON-RPC
+    error can be enriched with the real cause."""
+    pm = ProcessManager()
+    pm._initialized = True
+    pm._server_configs["stripe"] = _make_config("stripe")
+
+    class _FailingRunner:
+        state = ProcessState.STOPPED
+        _last_error = "missing API key: STRIPE_KEY not set"
+
+        async def call_tool(self, tool_name, arguments):
+            return {
+                "jsonrpc": "2.0",
+                "error": {"code": -32603, "message": "Server stripe failed to initialize"},
+            }
+
+    pm._runners["stripe"] = _FailingRunner()
+
+    result = await pm.call_tool_on_server("stripe", "create_customer", {})
+
+    assert "error" in result
+    health = pm.get_server_health("stripe")
+    assert health.status == "start_failed"
+    assert health.last_error == "missing API key: STRIPE_KEY not set"


### PR DESCRIPTION
Fixes #197

## What / why

Upstream failures were swallowed (correctly, for isolation) but invisible: a server with a missing API key or dead command just vanished from `tools/list`/`airis-find` with one log line — the user-facing symptom is "なんか一部壊れてる".

- **ServerHealth store** on ProcessManager (the layer that sees all failures): `ok / start_failed / list_failed / policy_disabled / disabled / not_started` + truncated `last_error` + `last_checked`. Isolation semantics unchanged — one bad server still never breaks listing.
- **airis-find**: tools of an unhealthy server carry `server_status`/`server_error` in both the structured result and the LLM-facing text (`[⚠ start_failed: …]`) — "found but currently broken, and here's why".
- **`GET /health/servers`**: full per-server map (name/mode/enabled/policy_disabled/status/last_error/last_checked); same no-auth posture as existing `/health`.
- **airis-exec** failures now include the health record + a config-check hint instead of a bare error.

## Acceptance (independently verified)

- `test_server_health_surfacing.py` → **10 passed** (RED pre-change: ImportError at collection with source stashed)
- `tests/unit` → **487 passed**, exit 0; coverage 54.29% (floor 52 intact)
- TestClient smoke: `GET /health/servers` → 200 with the documented shape

**Gate added/tightened:** `test_server_health_surfacing.py` — a failing server now MUST surface an annotation in find results (silent-vanish regression turns CI red).