### PR TITLE
feat: direct COLD tool exposure in tools/list — eliminate the meta-tool hop (Fixes #198)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ FastAPI-based MCP multiplexer that exposes many MCP servers (process + Docker Ga
 - **Streamable HTTP** at `http://localhost:9400/mcp/` — for Codex and Claude Code (recommended)
 - **SSE** at `http://localhost:9400/sse` — for Gemini CLI, Cursor, Windsurf
 
-Dynamic MCP mode (default) exposes only 4 meta-tools (`airis-find`, `airis-schema`, `airis-workflow`, `airis-exec`) instead of 60+ raw tools. COLD servers are not in `tools/list`; clients reach their tools through `airis-exec`, which auto-discovers and auto-enables the server on first call. (`airis-exec` is required because `tools/list`-only clients like Claude Code and Codex cannot call a tool that isn't advertised.)
+Dynamic MCP mode (default) exposes 4 meta-tools (`airis-find`, `airis-schema`, `airis-workflow`, `airis-exec`) plus every discoverable COLD server's indexed tools with a lazy stub schema (`{"type":"object"}`), instead of 60+ fully-schema'd raw tools. A client that only reads `tools/list` can call a COLD tool by name directly — the server auto-discovers and auto-enables it on first call, one hop, no meta-tool round trip. `airis-find`/`airis-schema` remain available as an optional discovery aid (server browsing, full schemas); `airis-exec` remains as the compat router for older clients. Set `COLD_TOOLS_IN_LIST=false` to restore the old meta-tool-only listing for context-constrained clients.
 
 Source of truth for server config: `mcp-config.json` (runtime) and `workflows/*.yaml`. Workflows split by `compile_to`: `mcp_instructions` ones are baked into the MCP `initialize` instructions by `apps/api/src/app/core/behavior_compiler.py`; `airis_workflow` ones are served on-demand by the `airis-workflow` meta-tool keyed by `topic`.
 
@@ -62,10 +62,10 @@ The API in `apps/api/src/app/api/endpoints/` is split into focused modules:
 
 ### HOT/COLD server split
 
-- **HOT**: ProcessManager process servers (uvx/npx/airis) always listed in `tools/list` — pre-warmed at API startup, never idle-killed. Default HOT set: `context7`, `airis-mcp-gateway-control`, `airis-workspace`.
-- **COLD**: Docker Gateway backend servers — not listed directly; auto-discovered via tools index on first native tool call, enabled on-demand.
+- **HOT**: ProcessManager process servers (uvx/npx/airis) always listed in `tools/list` with full schema — pre-warmed at API startup, never idle-killed. Default HOT set: `context7`, `airis-mcp-gateway-control`, `airis-workspace`.
+- **COLD**: Docker Gateway backend servers — listed directly in `tools/list` with a lazy stub schema (`COLD_TOOLS_IN_LIST=true`, default) via each server's `tools_index`; auto-discovered and auto-enabled on first `tools/call`.
 
-In DYNAMIC_MCP mode, `tools/list` returns only meta-tools + currently active HOT server tools. Full tool discovery goes through `airis-find`.
+In DYNAMIC_MCP mode, `tools/list` returns meta-tools + HOT server tools (full schema) + discoverable COLD server tools (stub schema, `{"type":"object"}`). `airis-find` remains available for browsing servers/tools and `airis-schema` for full schemas on demand.
 
 The `airis` CLI itself is baked into the gateway image (see `Dockerfile`, fetched from the airis-workspace GitHub release pinned via `AIRIS_VERSION`), so `airis-workspace`'s 27 tools (`workspace_init`, `workspace_gen`, `workspace_doctor`, `workspace_status`, `manifest_validate`, `manifest_apply`, `migration_execute`, etc.) are available out of the box without host installation. The gateway container mounts `${HOST_WORKSPACE_DIR:-${HOME}/github}` at `/workspace` so those tools can operate on real projects.
 
@@ -81,7 +81,7 @@ Note on JSON-RPC tolerance: airis-workspace emits `"error": null` alongside succ
 
 ## Dynamic MCP
 
-`DYNAMIC_MCP=true` (default) exposes 4 meta-tools: `airis-find` (discover tools), `airis-schema` (get input schema), `airis-workflow` (fetch a task-specific procedure by `topic`), `airis-exec` (execute any tool — the router for COLD-server tools that are not in `tools/list`). `META_TOOLS_MODE=full` adds `airis-confidence`, `airis-repo-index`, `airis-suggest`, `airis-route`. COLD servers auto-discover and auto-enable on the first `airis-exec` call.
+`DYNAMIC_MCP=true` (default) exposes 4 meta-tools — `airis-find` (discover tools/servers), `airis-schema` (get a tool's full input schema), `airis-workflow` (fetch a task-specific procedure by `topic`), `airis-exec` (compat router: execute any tool by name/`server:tool`) — plus, when `COLD_TOOLS_IN_LIST=true` (default), every discoverable COLD server's `tools_index` entries with a lazy stub schema. The primary path for a COLD tool is now a direct `tools/call` with the name learned from `tools/list`; the server auto-discovers and auto-enables on that first call, same as before. `airis-exec` is kept for clients that can't act on a bare `tools/list` name. `META_TOOLS_MODE=full` adds `airis-confidence`, `airis-repo-index`, `airis-suggest`, `airis-route`.
 
 Instructions returned on `initialize` are compiled from the `compile_to: mcp_instructions` `workflows/*.yaml` — **edit the YAML, not the Python**. Each needs `name`, `compile_to`, `priority`, and a `text:` block. Missing `text` makes it emit literal `compile_to` values (bug: 2026-04-14).
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Claude / Gemini / Cursor / Windsurf
 | **airis-workspace** | Docker-first workspace lifecycle (`manifest.toml` → `airis gen` → `airis up/test/...`) |
 | **airis-mcp-gateway-control** | Manage this gateway (servers, config, health) from inside the agent |
 
-### Enabled COLD — start on first tool call, auto-terminate when idle
+### COLD — listed in `tools/list` (lazy stub schema), start on first tool call, auto-terminate when idle
 
 | Server | Description |
 |--------|-------------|
@@ -183,19 +183,19 @@ Claude / Gemini / Cursor / Windsurf
 | **serena** | Semantic code retrieval and editing |
 | **morphllm** | Code editing with warpgrep |
 | **sequential-thinking** | Step-by-step reasoning |
-
-### Disabled — not registered, no advertised tools
-
-| Server | Description |
-|--------|-------------|
 | **postgres** | Direct PostgreSQL access |
-| **supabase** | Supabase database management — disabled, never authorized for this deployment |
-| **mindbase** | Local memory substrate (pgvector + Ollama) — disabled, never authorized for this deployment |
 | **filesystem** | File system operations |
 | **git** | Git operations |
 | **time** | Time utilities |
 
-Source of truth: [`mcp-config.json`](./mcp-config.json). HOT servers are always listed in `tools/list`; COLD servers are discovered via `airis-find` and called through `airis-exec`, which auto-enables the server on first call — no manual setup needed.
+### Policy-disabled — never advertised, never run
+
+| Server | Description |
+|--------|-------------|
+| **supabase** | Supabase database management — disabled, never authorized for this deployment |
+| **mindbase** | Local memory substrate (pgvector + Ollama) — disabled, never authorized for this deployment |
+
+Source of truth: [`mcp-config.json`](./mcp-config.json). HOT servers are always listed in `tools/list` with full schema. COLD servers are also listed directly, with a lazy stub schema (`{"type":"object"}`) — a client can call one by name straight from `tools/list` and it auto-enables on first call, no `airis-find`/`airis-exec` hop needed. `airis-find`/`airis-schema` remain available for browsing servers and fetching full schemas; `airis-exec` remains as a compat router for clients that can't act on a bare `tools/list` name.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Claude / Gemini / Cursor / Windsurf
 |--------|-------------|
 | **supabase** | Supabase database management — disabled, never authorized for this deployment |
 | **mindbase** | Local memory substrate (pgvector + Ollama) — disabled, never authorized for this deployment |
+| **cloudflare** | Cloudflare API access (KV, Workers, DNS) — disabled, never authorized for this deployment |
 
 Source of truth: [`mcp-config.json`](./mcp-config.json). HOT servers are always listed in `tools/list` with full schema. COLD servers are also listed directly, with a lazy stub schema (`{"type":"object"}`) — a client can call one by name straight from `tools/list` and it auto-enables on first call, no `airis-find`/`airis-exec` hop needed. `airis-find`/`airis-schema` remain available for browsing servers and fetching full schemas; `airis-exec` remains as a compat router for clients that can't act on a bare `tools/list` name.
 

--- a/apps/api/src/app/api/endpoints/tool_shaping.py
+++ b/apps/api/src/app/api/endpoints/tool_shaping.py
@@ -206,6 +206,67 @@ async def apply_prompts_merging(data: Dict[str, Any]) -> Dict[str, Any]:
     return data
 
 
+def collect_cold_discoverable_tools(process_manager) -> list[dict]:
+    """Build ``tools/list`` stub entries for every discoverable COLD server's
+    ``tools_index``, so a client that only reads ``tools/list`` can call a
+    COLD tool directly in one hop (no ``airis-find``/``airis-exec`` needed).
+
+    Naming: entries use the bare tool name exactly as stored in
+    ``tools_index`` (``tool_entry["name"]``, never ``"server:tool"``) —
+    this is what ``DynamicMCP.get_server_for_tool_from_index`` /
+    ``auto_discover_and_execute`` match against, so a listed name resolves
+    to the same server a raw ``tools/call`` would auto-discover.
+
+    Excludes ``policy_disabled`` servers via ``is_discoverable`` (issue
+    #193). Includes ``enabled=False`` COLD servers on purpose — those
+    auto-enable transparently on first call, which is the entire point of
+    listing them.
+
+    Collisions: if two servers index the same bare tool name (or a name
+    already claimed by a meta-/HOT-tool), the first occurrence wins and the
+    collision is logged once — auto-discovery itself is ambiguous for that
+    name, so listing both would be misleading either way.
+    """
+    from ...core.mcp_config_loader import ServerMode, is_discoverable
+
+    entries: list[dict] = []
+    seen_names: set[str] = set()
+
+    for name in process_manager.get_server_names():
+        config = process_manager._server_configs.get(name)
+        if not config or config.mode != ServerMode.COLD:
+            continue
+        if not is_discoverable(config):
+            continue
+
+        for tool_entry in config.tools_index or []:
+            tool_name = tool_entry.get("name")
+            if not tool_name:
+                continue
+            if tool_name in seen_names:
+                logger.warning(
+                    f"tools_index name collision for '{tool_name}' "
+                    f"(server '{name}'): keeping first occurrence, "
+                    f"auto-discovery is ambiguous for this name"
+                )
+                continue
+            seen_names.add(tool_name)
+
+            raw_description = tool_entry.get("description") or (
+                f"「{name}」server tool (auto-enables on first call)"
+            )
+            description = summarize_description(
+                raw_description, mode=settings.DESCRIPTION_MODE
+            )
+
+            entry = {"name": tool_name, "inputSchema": {"type": "object"}}
+            if description:
+                entry["description"] = description
+            entries.append(entry)
+
+    return entries
+
+
 async def _refresh_dynamic_mcp_cache(process_manager, docker_tools: list) -> None:
     """Background refresh of the Dynamic MCP cache (non-blocking)."""
     try:
@@ -296,9 +357,26 @@ async def apply_schema_partitioning(data: Dict[str, Any]) -> Dict[str, Any]:
 
         tools.extend(hot_tools_list)
 
+        # COLD servers: advertise their indexed tools directly with lazy
+        # stub schemas, so a client that only reads tools/list can call
+        # them in one hop instead of routing through airis-find/airis-exec
+        # (issue #198). Skip names already claimed by a meta-/HOT-tool.
+        cold_count = 0
+        if settings.COLD_TOOLS_IN_LIST:
+            existing_names = {t.get("name") for t in tools}
+            cold_tools_list = [
+                t for t in collect_cold_discoverable_tools(process_manager)
+                if t["name"] not in existing_names
+            ]
+            tools.extend(cold_tools_list)
+            cold_count = len(cold_tools_list)
+
         data["result"]["tools"] = tools
-        hot_count = len(tools) - meta_count
-        logger.info(f"Returning {len(tools)} tools ({meta_count} meta + {hot_count} native)")
+        hot_count = len(tools) - meta_count - cold_count
+        logger.info(
+            f"Returning {len(tools)} tools "
+            f"({meta_count} meta + {hot_count} native HOT + {cold_count} COLD stubs)"
+        )
 
         # Schedule background cache refresh (non-blocking)
         asyncio.create_task(_refresh_dynamic_mcp_cache(process_manager, docker_tools))

--- a/apps/api/src/app/core/config.py
+++ b/apps/api/src/app/core/config.py
@@ -113,6 +113,13 @@ class Settings(BaseSettings):
     # Meta-Tools Mode: "core" (3 tools: find/exec/schema) or "full" (all 7 including confidence/suggest/route)
     META_TOOLS_MODE: str = os.getenv("META_TOOLS_MODE", "core")
 
+    # COLD Tools In List: when true (default), tools/list advertises every
+    # discoverable COLD server's tools_index entries with a lazy stub
+    # schema, so clients can call them directly in one hop (issue #198).
+    # Set to false to restore the previous meta-tool-only COLD behavior for
+    # context-constrained clients.
+    COLD_TOOLS_IN_LIST: bool = os.getenv("COLD_TOOLS_IN_LIST", "true").lower() in ("true", "1", "yes")
+
     # Tool Listing Mode: "full" (all tool names) or "compact" (top 3 per server + count)
     TOOL_LISTING_MODE: str = os.getenv("TOOL_LISTING_MODE", "compact")
 

--- a/apps/api/src/app/core/dynamic_mcp.py
+++ b/apps/api/src/app/core/dynamic_mcp.py
@@ -575,14 +575,35 @@ class DynamicMCP:
         """
         Look up server name from tools_index in mcp-config.json.
         Used for auto-discovery when tool is not in cache.
+
+        Discoverable (non policy_disabled) servers are matched first, so a
+        bare tool name resolves to the same server the exposure collector
+        advertised it under whenever a discoverable candidate exists (see
+        is_discoverable / issue #198) — this is what fixes 'query' (indexed
+        by both policy-disabled supabase and discoverable postgres)
+        resolving to supabase instead of the advertised postgres.
+
+        Non-discoverable servers are only used as a fallback when no
+        discoverable server indexes the name, so a bare call for a tool that
+        exists *solely* on a policy-disabled server still resolves to it and
+        gets the explicit -32001 policy-disabled refusal in
+        auto_discover_and_execute (rather than a generic "not found"),
+        matching explicit `server:tool` addressing which bypasses this
+        resolver entirely and always hits that refusal.
         """
+        fallback: Optional[str] = None
         for name in process_manager.get_server_names():
             config = process_manager._server_configs.get(name)
-            if config and config.tools_index:
-                for tool_entry in config.tools_index:
-                    if tool_entry.get("name") == tool_name:
+            if not config or not config.tools_index:
+                continue
+            for tool_entry in config.tools_index:
+                if tool_entry.get("name") == tool_name:
+                    if is_discoverable(config):
                         return name
-        return None
+                    if fallback is None:
+                        fallback = name
+                    break
+        return fallback
 
     async def auto_discover_and_execute(
         self, tool_name: str, arguments: dict, process_manager

--- a/apps/api/tests/unit/test_cold_tools_direct_exposure.py
+++ b/apps/api/tests/unit/test_cold_tools_direct_exposure.py
@@ -218,6 +218,63 @@ async def test_every_discoverable_cold_indexed_tool_is_listed(monkeypatch):
     assert not missing, f"COLD indexed tools missing from tools/list: {missing}"
 
 
+@pytest.mark.asyncio
+async def test_advertised_cold_name_resolves_to_the_server_it_was_attributed_to(
+    monkeypatch,
+):
+    """Resolver/collector parity canary (issue #198 review finding 1): every
+    COLD tool name advertised in tools/list must resolve, via
+    DynamicMCP.get_server_for_tool_from_index, to a discoverable server —
+    and specifically the SAME server the collector attributed it to.
+
+    Regression this guards: `query` is indexed by both `supabase`
+    (policy_disabled) and `postgres` (discoverable) in the real registry.
+    The collector skips supabase and advertises `query` for postgres, but a
+    resolver that iterates ALL servers (including policy_disabled ones)
+    without the same is_discoverable() filter can return supabase first —
+    so calling the advertised name silently 1-hops into the wrong,
+    policy-disabled server instead of the one that was listed.
+    """
+    from app.core.mcp_config_loader import is_discoverable, load_mcp_config
+
+    parsed = load_mcp_config(str(REPO_ROOT / "mcp-config.json.example"))
+
+    pm = _build_pm(monkeypatch)
+    pm._server_configs = dict(parsed)
+
+    # Mirror collect_cold_discoverable_tools()'s exact attribution: iterate
+    # servers in the same order, first occurrence of a bare name wins.
+    attributed_server: dict[str, str] = {}
+    for name in pm.get_server_names():
+        config = pm._server_configs.get(name)
+        if not config or config.mode != ServerMode.COLD:
+            continue
+        if not is_discoverable(config):
+            continue
+        for tool_entry in config.tools_index or []:
+            tool_name = tool_entry.get("name")
+            if not tool_name or tool_name in attributed_server:
+                continue
+            attributed_server[tool_name] = name
+
+    listed_names = {t["name"] for t in await _list_tools(pm)}
+    dmcp = DynamicMCP()
+
+    for tool_name in listed_names & attributed_server.keys():
+        resolved = dmcp.get_server_for_tool_from_index(tool_name, pm)
+        expected_server = attributed_server[tool_name]
+        assert resolved == expected_server, (
+            f"advertised tool '{tool_name}' resolves to server "
+            f"'{resolved}' but was advertised under '{expected_server}' "
+            f"(collector/resolver disagree — see is_discoverable filter)"
+        )
+        resolved_config = pm._server_configs.get(resolved)
+        assert resolved_config and is_discoverable(resolved_config), (
+            f"advertised tool '{tool_name}' resolved to non-discoverable "
+            f"server '{resolved}'"
+        )
+
+
 # ── Token budget guard ───────────────────────────────────────────────────
 
 
@@ -225,7 +282,7 @@ async def test_every_discoverable_cold_indexed_tool_is_listed(monkeypatch):
 async def test_tools_list_json_size_stays_within_budget(monkeypatch):
     """Guard against description-bloat regressions. The measured serialized
     size (meta-tools + all discoverable COLD stubs, from the real registry
-    mirror) was ~4.0KB at the time this test was written; ceiling is 1.5x
+    mirror) was ~9.0KB at the time this test was written; ceiling is 1.5x
     that measured value to leave headroom for legitimate registry growth
     while still catching a bloat regression."""
     from app.core.mcp_config_loader import load_mcp_config

--- a/apps/api/tests/unit/test_cold_tools_direct_exposure.py
+++ b/apps/api/tests/unit/test_cold_tools_direct_exposure.py
@@ -1,0 +1,301 @@
+"""
+Tests for direct COLD-tool exposure in tools/list (issue #198).
+
+Background (already true before this change): a bare tools/call for a COLD
+tool already works in one hop via DynamicMCP.auto_discover_and_execute
+(tools_index lookup + auto-enable + self-heal on -32602). The only missing
+piece was that clients could not learn COLD tool names from tools/list at
+all, forcing them through airis-find -> airis-exec (2-3 hops).
+
+This module tests apply_schema_partitioning()'s new behavior: every
+discoverable (non policy_disabled) COLD server's tools_index entries are
+now advertised directly in tools/list with a lazy stub schema
+({"type": "object"}), using the bare tool name exactly as
+DynamicMCP.auto_discover_and_execute resolves it.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.api.endpoints import tool_shaping
+from app.core.config import settings
+from app.core.dynamic_mcp import DynamicMCP
+from app.core.mcp_config_loader import McpServerConfig, ServerMode
+from app.core.process_manager import ProcessManager
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _make_config(
+    name: str,
+    *,
+    enabled: bool = True,
+    mode: ServerMode = ServerMode.COLD,
+    tools_index: list[dict] | None = None,
+    policy_disabled: bool = False,
+) -> McpServerConfig:
+    return McpServerConfig(
+        name=name,
+        server_type="process",
+        command="uvx",
+        args=["test-server"],
+        env={},
+        enabled=enabled,
+        policy_disabled=policy_disabled,
+        mode=mode,
+        tools_index=tools_index or [],
+    )
+
+
+def _wire_process_manager(pm: ProcessManager) -> None:
+    """See test_cold_tool_auto_discovery.py — same wiring pattern."""
+    pm.get_server_names = lambda: list(pm._server_configs.keys())
+    pm.is_process_server = lambda name: name in pm._server_configs
+
+
+def _build_pm(monkeypatch, *, hot_servers=None) -> ProcessManager:
+    pm = ProcessManager()
+    pm._initialized = True
+    _wire_process_manager(pm)
+    pm.get_hot_servers = lambda: list(hot_servers or [])
+    pm.list_tools = AsyncMock(return_value=[])
+    monkeypatch.setattr(tool_shaping, "get_process_manager", lambda: pm)
+    monkeypatch.setattr(tool_shaping, "get_dynamic_mcp", lambda: DynamicMCP())
+    monkeypatch.setattr(settings, "DYNAMIC_MCP", True)
+    monkeypatch.setattr(settings, "SCHEMA_MODE", "lazy")
+    monkeypatch.setattr(settings, "COLD_TOOLS_IN_LIST", True)
+    return pm
+
+
+async def _list_tools(pm) -> list[dict]:
+    data = {"jsonrpc": "2.0", "id": 1, "result": {"tools": []}}
+    out = await tool_shaping.apply_schema_partitioning(data)
+    return out["result"]["tools"]
+
+
+# ── Core behavior ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cold_server_tools_appear_in_tools_list_with_stub_schema(monkeypatch):
+    pm = _build_pm(monkeypatch)
+    pm._server_configs["stripe"] = _make_config(
+        "stripe",
+        enabled=False,
+        tools_index=[
+            {"name": "create_customer", "description": "Create a Stripe customer"},
+            {"name": "list_charges", "description": "List Stripe charges"},
+        ],
+    )
+
+    tools = {t["name"]: t for t in await _list_tools(pm)}
+
+    assert "create_customer" in tools, tools.keys()
+    assert "list_charges" in tools, tools.keys()
+    assert tools["create_customer"]["inputSchema"] == {"type": "object"}
+    assert tools["create_customer"]["description"]
+
+
+@pytest.mark.asyncio
+async def test_policy_disabled_server_tools_are_not_listed(monkeypatch):
+    """supabase / mindbase (policy_disabled) must never be advertised."""
+    pm = _build_pm(monkeypatch)
+    pm._server_configs["supabase"] = _make_config(
+        "supabase",
+        enabled=False,
+        policy_disabled=True,
+        tools_index=[{"name": "query", "description": "Execute a SQL query"}],
+    )
+    pm._server_configs["mindbase"] = _make_config(
+        "mindbase",
+        enabled=False,
+        policy_disabled=True,
+        tools_index=[{"name": "conversation_search", "description": "Search conversations"}],
+    )
+
+    tools = {t["name"] for t in await _list_tools(pm)}
+
+    assert "query" not in tools
+    assert "conversation_search" not in tools
+
+
+@pytest.mark.asyncio
+async def test_hot_mode_server_tools_index_is_not_duplicated_via_cold_path(monkeypatch):
+    """A HOT server's tools_index must not be re-listed through the COLD
+    stub path (it already gets full exposure via get_hot_servers/list_tools)."""
+    pm = _build_pm(monkeypatch)
+    pm._server_configs["airis-workspace"] = _make_config(
+        "airis-workspace",
+        mode=ServerMode.HOT,
+        enabled=True,
+        tools_index=[{"name": "workspace_init", "description": "Scan the repo"}],
+    )
+
+    tools = {t["name"] for t in await _list_tools(pm)}
+    assert "workspace_init" not in tools
+
+
+@pytest.mark.asyncio
+async def test_cold_tools_in_list_false_restores_old_meta_tool_only_listing(monkeypatch):
+    pm = _build_pm(monkeypatch)
+    monkeypatch.setattr(settings, "COLD_TOOLS_IN_LIST", False)
+    pm._server_configs["stripe"] = _make_config(
+        "stripe",
+        enabled=False,
+        tools_index=[{"name": "create_customer", "description": "Create a Stripe customer"}],
+    )
+
+    tools = {t["name"] for t in await _list_tools(pm)}
+
+    assert "create_customer" not in tools
+    # Meta-tools are still present.
+    assert "airis-find" in tools
+    assert "airis-exec" in tools
+
+
+@pytest.mark.asyncio
+async def test_collision_keeps_first_occurrence_and_does_not_crash(monkeypatch):
+    pm = _build_pm(monkeypatch)
+    pm._server_configs["stripe"] = _make_config(
+        "stripe",
+        enabled=False,
+        tools_index=[{"name": "shared_name", "description": "From stripe"}],
+    )
+    pm._server_configs["github"] = _make_config(
+        "github",
+        enabled=True,
+        tools_index=[{"name": "shared_name", "description": "From github"}],
+    )
+
+    tools = [t for t in await _list_tools(pm) if t["name"] == "shared_name"]
+    assert len(tools) == 1, "colliding tool name must appear exactly once"
+
+
+# ── Completeness canary ──────────────────────────────────────────────────
+
+
+def _discoverable_cold_index_names_from_registry() -> set[str]:
+    """Every tools_index name on a COLD, non policy_disabled server in the
+    tracked registry mirror. Mirrors is_discoverable()'s policy_disabled-only
+    gate."""
+    data = json.loads((REPO_ROOT / "mcp-config.json.example").read_text())
+    names: set[str] = set()
+    for cfg in data["mcpServers"].values():
+        if cfg.get("mode") != "cold":
+            continue
+        if cfg.get("policy_disabled"):
+            continue
+        for entry in cfg.get("tools_index") or []:
+            if entry.get("name"):
+                names.add(entry["name"])
+    return names
+
+
+@pytest.mark.asyncio
+async def test_every_discoverable_cold_indexed_tool_is_listed(monkeypatch):
+    """Completeness canary: load the real mcp-config.json.example registry
+    through mcp_config_loader and assert every discoverable COLD indexed
+    tool name shows up in the produced tools/list. Prevents future
+    partial-exposure drift (e.g. someone gating on a subset of servers)."""
+    from app.core.mcp_config_loader import load_mcp_config
+
+    parsed = load_mcp_config(str(REPO_ROOT / "mcp-config.json.example"))
+
+    pm = _build_pm(monkeypatch)
+    pm._server_configs = dict(parsed)
+
+    listed_names = {t["name"] for t in await _list_tools(pm)}
+    expected = _discoverable_cold_index_names_from_registry()
+
+    missing = expected - listed_names
+    assert not missing, f"COLD indexed tools missing from tools/list: {missing}"
+
+
+# ── Token budget guard ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_tools_list_json_size_stays_within_budget(monkeypatch):
+    """Guard against description-bloat regressions. The measured serialized
+    size (meta-tools + all discoverable COLD stubs, from the real registry
+    mirror) was ~4.0KB at the time this test was written; ceiling is 1.5x
+    that measured value to leave headroom for legitimate registry growth
+    while still catching a bloat regression."""
+    from app.core.mcp_config_loader import load_mcp_config
+
+    parsed = load_mcp_config(str(REPO_ROOT / "mcp-config.json.example"))
+
+    pm = _build_pm(monkeypatch)
+    pm._server_configs = dict(parsed)
+
+    tools = await _list_tools(pm)
+    size = len(json.dumps(tools))
+
+    # Measured at write time: ~9.0KB serialized (meta-tools + COLD stubs
+    # from mcp-config.json.example, no HOT server tools since none are
+    # wired to respond in this stub ProcessManager).
+    MEASURED_BASELINE = 9010
+    ceiling = int(MEASURED_BASELINE * 1.5)
+    assert size <= ceiling, (
+        f"tools/list serialized size {size} bytes exceeds {ceiling} byte "
+        f"budget ({MEASURED_BASELINE} baseline * 1.5) — check for "
+        f"description bloat in tools_index or the COLD stub builder"
+    )
+
+
+# ── End-to-end 1-hop proof (reuses auto-discovery machinery) ────────────
+
+
+@pytest.mark.asyncio
+async def test_tools_list_advertised_name_is_directly_callable_one_hop(monkeypatch):
+    """A client that ONLY reads tools/list learns the bare tool name from
+    this module's stub entry, then calls it directly via tools/call and it
+    resolves through DynamicMCP.auto_discover_and_execute with no
+    airis-find/airis-exec round trip — proving the advertised name is
+    exactly what auto-discovery expects."""
+    pm = _build_pm(monkeypatch)
+    pm._server_configs["stripe"] = _make_config(
+        "stripe",
+        enabled=False,
+        tools_index=[{"name": "create_customer", "description": "Create a Stripe customer"}],
+    )
+
+    # Step 1: client reads tools/list and learns the name.
+    tools = {t["name"] for t in await _list_tools(pm)}
+    assert "create_customer" in tools
+
+    # Step 2: client calls that exact name directly via tools/call, with no
+    # server prefix and no airis-find/airis-exec involved — proving the
+    # 1-hop path (mirrors test_cold_tool_auto_discovery.py's
+    # test_cold_tool_auto_discovered_and_executed).
+    call_log = []
+
+    async def fake_enable_server(name):
+        pm._server_configs[name].enabled = True
+        call_log.append(f"enable:{name}")
+
+    async def fake_call_tool_on_server(server_name, tool_name, arguments):
+        call_log.append(f"call:{server_name}:{tool_name}")
+        return {"result": {"content": [{"type": "text", "text": "ok"}], "isError": False}}
+
+    async def fake_load_tools_for_server(server_name, process_manager, force_enable=False):
+        pm._tool_to_server["create_customer"] = "stripe"
+
+    monkeypatch.setattr(pm, "enable_server", fake_enable_server)
+    monkeypatch.setattr(pm, "call_tool_on_server", fake_call_tool_on_server)
+
+    dmcp = DynamicMCP()
+    monkeypatch.setattr(dmcp, "load_tools_for_server", fake_load_tools_for_server)
+
+    result = await dmcp.auto_discover_and_execute("create_customer", {"email": "x@y.com"}, pm)
+
+    assert result == {"result": {"content": [{"type": "text", "text": "ok"}], "isError": False}}
+    assert "enable:stripe" in call_log
+    assert "call:stripe:create_customer" in call_log


### PR DESCRIPTION
Fixes #198

## What / why — the de-hop

COLD tools required `airis-find` → (`airis-schema`) → `airis-exec` (2–3 hops) solely because clients couldn't learn the names from `tools/list` — the 1-hop `tools/call` path (auto-discover + auto-enable + validation-error schema self-heal) already existed. This PR adds the missing piece:

- **`tools/list` now advertises every discoverable COLD tool** (bare `tools_index` name = exactly what auto-discovery resolves; `{"type":"object"}` lazy stub schema; brief description with auto-enable note). `policy_disabled` servers (supabase/mindbase) stay hidden; name collisions dedupe first-wins with a warning.
- **Context cost measured**: 4 tools / 2,152 bytes → 60 tools / 9,010 bytes against the example registry — flat, because schemas stay stubbed. Deferred-tools clients (Claude Code ToolSearch) pay ~zero.
- **`COLD_TOOLS_IN_LIST=false`** restores the old meta-only listing for context-constrained clients. Meta-tools remain fully functional as the compat path.
- Docs (CLAUDE.md / README) updated: direct `tools/call` is the primary path; find/schema are optional aids. Out of scope (follow-ups): `notifications/tools/list_changed`, trimming full-mode meta extras.

## Acceptance (independently verified)

- New suite **8 passed** (RED pre-change); `tests/unit` → **496 passed**; coverage 56.12% (floor 52)
- 1-hop e2e proof: a client that only read `tools/list` calls `create_customer` via bare-name auto-discovery — no airis-find/airis-exec involved
- All prior gates green (drift / meta-consistency / no-fixed-sleep)

**Gate added/tightened:** completeness canary (every discoverable COLD indexed tool MUST appear in the listing — partial-exposure drift turns CI red) + token-budget ceiling on the serialized listing (description bloat turns CI red).