### PR TITLE
chore: remove unused airis-legal routing entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,6 @@ Claude / Gemini / Cursor / Windsurf
 | Server | Description |
 |--------|-------------|
 | **airis-commands** | Slash-command toolkit shipped with the gateway |
-| **airis-legal** | Japanese court document automation (証拠説明書 / 準備書面) |
 | **fetch** | Fetch a URL and return it as markdown |
 | **tavily** | Web search via Tavily API |
 | **stripe** | Stripe payments API |

--- a/routing-table.json
+++ b/routing-table.json
@@ -1,5 +1,4 @@
 { "routes": [
-  {"pattern": "証拠説明書|準備書面|号証|甲号証|乙号証|訴訟|court document|legal case", "chain": ["airis-legal:*"], "hint": "Japanese legal document automation"},
   {"pattern": "research|investigate|search web", "chain": ["tavily:search"], "hint": "Web research"},
   {"pattern": "implement|build|code", "chain": ["airis-confidence","context7:get-library-docs"], "hint": "Implementation"},
   {"pattern": "database|sql|query", "chain": ["supabase:query"], "hint": "Database"},


### PR DESCRIPTION
## Summary
- Removes the `airis-legal` MCP server entry from `routing-table.json` and its mention in `README.md`.
- `airis-legal` is unused; the corresponding global CLI symlink (`~/.local/bin/airis-legal`) and its `mcp-config.json` (gitignored, local) entry were already removed on the host machine.

## Test plan
- [x] No code paths reference `airis-legal` outside its own repo (verified via repo-wide grep)
- [x] `routing_engine.py` tests are pattern-driven and don't hardcode this entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)