### PR TITLE
fix(api): exempt read-only MCP transport (GET/HEAD) from per-IP rate limiter

### DIFF
--- a/apps/api/src/app/middleware/rate_limit.py
+++ b/apps/api/src/app/middleware/rate_limit.py
@@ -33,6 +33,24 @@ RATE_LIMIT_WINDOW = 60  # seconds (fixed at 1 minute)
 # Paths excluded from rate limiting (monitoring endpoints)
 EXCLUDED_PATHS = frozenset({"/health", "/ready", "/metrics"})
 
+# MCP Streamable HTTP transport paths (see main.py's `include_router(mcp_proxy.router,
+# prefix="/mcp")` and `mcp_proxy.py`'s `/.well-known/{path:path}` route). GET/HEAD on
+# these paths are NOT per-request traffic: per the MCP Streamable HTTP spec
+# (2025-11-25), GET opens a long-lived server->client SSE stream (and resumes it after
+# a disconnect via `Last-Event-ID`), and `/.well-known/*` is a one-shot discovery
+# probe. A single MCP client can hold one GET stream open for hours and reconnect
+# many times; counting each of those against the fixed-window counter would exhaust
+# the budget fast. Because this gateway binds to localhost, every local MCP client
+# (Claude Code, Cursor, Codex, ...) shares the same 127.0.0.1 IP key, so counting
+# GET/HEAD here would lock out ALL of them from a single client's reconnect storm.
+# POST (JSON-RPC calls) and DELETE (session termination) are genuine per-request
+# traffic and stay rate-limited below.
+# This exemption is only safe because the gateway is localhost/trusted-proxy bound;
+# a public-facing deployment should instead cap concurrent SSE connections per key
+# rather than exempting GET/HEAD outright.
+MCP_TRANSPORT_READ_PATHS = frozenset({"/mcp", "/mcp/"})
+MCP_WELL_KNOWN_PREFIX = "/.well-known/"
+
 # Trusted proxy CIDRs — only trust X-Forwarded-For from these sources.
 # Default: Docker bridge + loopback. Override via TRUSTED_PROXIES env var
 # (comma-separated CIDRs, e.g. "10.0.0.0/8,172.16.0.0/12").
@@ -167,6 +185,19 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         # Skip rate limiting for monitoring endpoints
         if request.url.path in EXCLUDED_PATHS:
             return await call_next(request)
+
+        # Skip rate limiting for read-only MCP transport traffic (long-lived SSE
+        # streams, resumption reconnects, discovery probes). See
+        # MCP_TRANSPORT_READ_PATHS above for why these are exempt.
+        if request.method in {"GET", "HEAD"}:
+            path = request.url.path
+            normalized_path = path.rstrip("/") or "/"
+            if (
+                normalized_path in MCP_TRANSPORT_READ_PATHS
+                or path.startswith(MCP_WELL_KNOWN_PREFIX)
+                or f"/mcp{MCP_WELL_KNOWN_PREFIX}" in path
+            ):
+                return await call_next(request)
 
         # Determine key and limit
         key, limit = self._get_key_and_limit(request)

--- a/apps/api/tests/unit/test_rate_limit_mcp_exempt.py
+++ b/apps/api/tests/unit/test_rate_limit_mcp_exempt.py
@@ -1,0 +1,76 @@
+"""Tests for MCP Streamable HTTP transport GET/HEAD rate-limit exemption."""
+from __future__ import annotations
+
+from starlette.applications import Starlette
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from app.middleware.rate_limit import RateLimitMiddleware, RateLimitStore
+
+
+async def _ok(request):
+    return PlainTextResponse("ok")
+
+
+def _build_client() -> TestClient:
+    """Build a minimal Starlette app with the rate-limit middleware wired up.
+
+    Uses a fresh RateLimitStore per test to avoid cross-test pollution of the
+    global store.
+    """
+    app = Starlette(
+        routes=[
+            Route("/mcp", _ok, methods=["GET", "HEAD"]),
+            Route("/mcp/", _ok, methods=["GET", "HEAD"]),
+            Route("/api/v1/data", _ok, methods=["POST"]),
+        ]
+    )
+    store = RateLimitStore()
+    app.add_middleware(RateLimitMiddleware, store=store)
+    return TestClient(app)
+
+
+def test_get_mcp_beyond_limit_is_exempt():
+    client = _build_client()
+
+    # Fire far more GET requests than the default per-IP limit (100/min).
+    for _ in range(150):
+        response = client.get("/mcp")
+        assert response.status_code == 200
+
+    # Trailing-slash variant is exempt too.
+    for _ in range(50):
+        response = client.get("/mcp/")
+        assert response.status_code == 200
+
+
+def test_head_mcp_beyond_limit_is_exempt():
+    client = _build_client()
+
+    for _ in range(150):
+        response = client.head("/mcp")
+        assert response.status_code == 200
+
+
+def test_post_still_rate_limited_after_exceeding_limit():
+    app = Starlette(
+        routes=[
+            Route("/api/v1/data", _ok, methods=["POST"]),
+        ]
+    )
+    store = RateLimitStore()
+    app.add_middleware(RateLimitMiddleware, store=store)
+    client = TestClient(app)
+
+    # Pre-fill the store so the very next POST from this client IP exceeds
+    # the per-IP limit, without needing to send hundreds of real requests.
+    from app.middleware.rate_limit import RATE_LIMIT_PER_IP
+
+    key = "ip:testclient"
+    store.check_and_increment(key, RATE_LIMIT_PER_IP)
+    store._store[key].count = RATE_LIMIT_PER_IP
+
+    response = client.post("/api/v1/data")
+    assert response.status_code == 429
+    assert "Retry-After" in response.headers


### PR DESCRIPTION
## Problem
The gateway binds to localhost, so **every local MCP client (Claude Code, Cursor, Codex, …) shares the same `127.0.0.1` rate-limit key**. The per-IP fixed-window limiter (100 req/min) counts MCP Streamable-HTTP transport GETs — long-lived SSE streams, not per-request traffic — so one client's reconnect storm can lock out **all** local clients.

## Root cause (per latest official spec)
Per the [MCP Streamable HTTP transport spec (2025-11-25)](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports): the `/mcp` endpoint uses **GET to open a long-lived server→client SSE stream** (and resume via `Last-Event-ID`), POST to send JSON-RPC, DELETE to terminate the session. `/.well-known/*` is a one-shot discovery probe. GET/HEAD are persistent/idempotent transport connections, not discrete requests.

## Fix
Exempt **GET/HEAD** on `/mcp`, `/mcp/` and `/.well-known/*` from the per-IP counter, short-circuiting **before** the counter increments. **POST**/**DELETE** stay rate-limited. Safe only because the gateway is localhost/trusted-proxy bound.

Surgical: only `rate_limit.py` + a new unit test.

> Follow-up (out of scope): the middleware stack is all `BaseHTTPMiddleware`, which Starlette now discourages for streaming/SSE paths — worth a separate issue to migrate to pure ASGI.

## Tests
501 passed + 3 new (exempt GET/HEAD, still-limited POST). `ruff` clean. Independently verified in a fresh context.