### PR TITLE
docs(readme): sync Available Servers table with mcp-config.json.example

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ Claude / Gemini / Cursor / Windsurf
 | **filesystem** | File system operations |
 | **git** | Git operations |
 | **time** | Time utilities |
+| **notebooklm** | NotebookLM notebooks (create, chat, delete) |
+| **airis-legal** | agiletec-inc/airis-legal document automation (証拠説明書/準備書面) |
 
 ### Policy-disabled — never advertised, never run
 
@@ -195,7 +197,7 @@ Claude / Gemini / Cursor / Windsurf
 | **mindbase** | Local memory substrate (pgvector + Ollama) — disabled, never authorized for this deployment |
 | **cloudflare** | Cloudflare API access (KV, Workers, DNS) — disabled, never authorized for this deployment |
 
-Source of truth: [`mcp-config.json`](./mcp-config.json). HOT servers are always listed in `tools/list` with full schema. COLD servers are also listed directly, with a lazy stub schema (`{"type":"object"}`) — a client can call one by name straight from `tools/list` and it auto-enables on first call, no `airis-find`/`airis-exec` hop needed. `airis-find`/`airis-schema` remain available for browsing servers and fetching full schemas; `airis-exec` remains as a compat router for clients that can't act on a bare `tools/list` name.
+Source of truth: [`mcp-config.json`](./mcp-config.json). HOT servers are always listed in `tools/list` with full schema. COLD servers are also listed directly, with a lazy stub schema (`{"type":"object"}`) — a client can call one by name straight from `tools/list` and it auto-enables on first call, no `airis-find`/`airis-exec` hop needed. `airis-find`/`airis-schema` remain available for browsing servers and fetching full schemas; `airis-workflow` fetches a task-specific procedure by topic; `airis-exec` remains as a compat router for clients that can't act on a bare `tools/list` name.
 
 </details>
 


### PR DESCRIPTION
## Summary
- README's Available Servers table was missing two `enabled: true` COLD servers present in `mcp-config.json.example`: `notebooklm` and `airis-legal`.
- The meta-tool footnote listed `airis-find`/`airis-schema`/`airis-exec` but omitted `airis-workflow`, which CLAUDE.md documents as a real 4th meta-tool.

## Test plan
- [x] Docs-only change, no code/build affected.
- [x] Verified `notebooklm` and `airis-legal` entries exist and are `enabled: true` in `mcp-config.json.example`.
- [x] Verified `airis-workflow` is a real meta-tool per this repo's `CLAUDE.md` Dynamic MCP section.