### PR TITLE
fix: concurrent tools/call on one Streamable HTTP session steals each other's response (Fixes #210)

### DIFF
--- a/apps/api/src/app/api/endpoints/gateway_stream_bridge.py
+++ b/apps/api/src/app/api/endpoints/gateway_stream_bridge.py
@@ -376,6 +376,15 @@ async def send_via_stream_bridge(
     # path only when there's at least one notification to deliver, so the
     # fast path for routine tool calls stays plain JSON.
     pending_notifications: list[dict] = []
+    # Bounds how many times THIS call will bounce a given foreign id back
+    # onto the queue before giving up on it. A live sibling waiting on that
+    # id reclaims it within one or two bounces (asyncio.Queue getters are
+    # FIFO-fair); an id with no live owner left (its call already timed out
+    # or disconnected) would otherwise requeue-and-redraw forever with no
+    # other reader to ever claim it — a synchronous busy loop pinning the
+    # event loop, not a bounded wait (see #210 review finding).
+    MAX_FOREIGN_ID_REQUEUES = 5
+    foreign_id_requeue_counts: dict = {}
 
     while True:
         try:
@@ -452,7 +461,23 @@ async def send_via_stream_bridge(
         # Response for a different concurrent call on the same session
         # (e.g. two overlapping tools/call requests sharing one
         # Mcp-Session-Id). Re-queue it so the caller actually waiting on
-        # that id can pick it up, instead of silently dropping it here.
+        # that id can pick it up — but only a bounded number of times per
+        # id: if nobody ever claims it (its own call already timed out or
+        # disconnected before this arrived), stop bouncing it and drop it
+        # instead of spinning forever with no other reader left to claim it.
+        payload_id = get_response_message_id(payload)
+        requeue_count = foreign_id_requeue_counts.get(payload_id, 0) + 1
+        if requeue_count > MAX_FOREIGN_ID_REQUEUES:
+            logger.warning(
+                "Dropping orphaned Gateway response for session %s: id=%r was "
+                "requeued %d times with no caller claiming it",
+                session.public_session_id,
+                payload_id,
+                requeue_count - 1,
+            )
+            foreign_id_requeue_counts.pop(payload_id, None)
+            continue
+        foreign_id_requeue_counts[payload_id] = requeue_count
         await session.response_queue.put(payload)
         continue
 

--- a/apps/api/src/app/api/endpoints/gateway_stream_bridge.py
+++ b/apps/api/src/app/api/endpoints/gateway_stream_bridge.py
@@ -449,6 +449,13 @@ async def send_via_stream_bridge(
                 headers={stream_session_header_name(): session.public_session_id},
             )
 
+        # Response for a different concurrent call on the same session
+        # (e.g. two overlapping tools/call requests sharing one
+        # Mcp-Session-Id). Re-queue it so the caller actually waiting on
+        # that id can pick it up, instead of silently dropping it here.
+        await session.response_queue.put(payload)
+        continue
+
 
 async def cleanup_stale_stream_bridges() -> int:
     """Tear down StreamBridgeSession entries that have been idle for too long.

--- a/apps/api/src/app/api/endpoints/gateway_stream_bridge.py
+++ b/apps/api/src/app/api/endpoints/gateway_stream_bridge.py
@@ -88,6 +88,12 @@ class StreamBridgeSession:
     response_queue: asyncio.Queue = field(default_factory=asyncio.Queue)
     closed: bool = False
     reader_task: Optional[asyncio.Task] = None
+    # ids currently owned by a live send_via_stream_bridge() waiter on this
+    # session. Lets a concurrent caller distinguish "still owned by a live
+    # sibling — keep requeuing" from "orphaned, nobody left to claim it —
+    # drop it" without a magic retry-count heuristic (a fixed count can't
+    # tell "several live bystanders" from "no owner left" — see #210 review).
+    pending_response_ids: set = field(default_factory=set)
     created_at: float = field(default_factory=_time_module.monotonic)
     last_activity: float = field(default_factory=_time_module.monotonic)
 
@@ -333,86 +339,26 @@ async def send_via_stream_bridge(
         f"{settings.MCP_GATEWAY_URL.rstrip('/')}/sse?sessionid={session.backend_session_id}"
     )
     expected_id = get_response_message_id(rpc_request)
+    # Register this call as a live waiter for expected_id BEFORE dispatching
+    # the POST — not after it returns — so that by the time any response
+    # could possibly reach the shared queue (which requires a real Gateway
+    # round trip: this POST lands, the Gateway processes it, and its SSE
+    # reader forwards the answer), this id is already known to be live. A
+    # concurrent sibling call's requeue decision below can then trust
+    # membership in this set instead of a magic retry count, which can't
+    # tell "several live bystanders" from "no owner left" (see #210 review).
+    if expected_id is not None:
+        session.pending_response_ids.add(expected_id)
 
     try:
-        response = await session.client.post(
-            target_url,
-            json=rpc_request,
-            headers={"Content-Type": "application/json"},
-        )
-    except Exception as exc:  # noqa: BLE001
-        logger.error("Failed to send bridged request to Gateway: %s", exc)
-        return Response(
-            content=json.dumps(
-                {
-                    "jsonrpc": "2.0",
-                    "id": rpc_request.get("id"),
-                    "error": {
-                        "code": -32000,
-                        "message": f"Failed to reach Gateway session: {exc}",
-                    },
-                }
-            ),
-            status_code=502,
-            media_type="application/json",
-            headers={stream_session_header_name(): session.public_session_id},
-        )
-    if response.status_code not in (200, 202):
-        return Response(
-            content=response.text,
-            status_code=response.status_code,
-            media_type=response.headers.get("content-type"),
-        )
-
-    if "id" not in rpc_request:
-        return Response(
-            status_code=202,
-            headers={stream_session_header_name(): session.public_session_id},
-        )
-
-    # Buffer server-to-client notifications that arrive before the matching
-    # response. The MCP Streamable HTTP spec lets the server answer a single
-    # POST with either a JSON body or an SSE event stream; we use the SSE
-    # path only when there's at least one notification to deliver, so the
-    # fast path for routine tool calls stays plain JSON.
-    pending_notifications: list[dict] = []
-    # Bounds how many times THIS call will bounce a given foreign id back
-    # onto the queue before giving up on it. A live sibling waiting on that
-    # id reclaims it within one or two bounces (asyncio.Queue getters are
-    # FIFO-fair); an id with no live owner left (its call already timed out
-    # or disconnected) would otherwise requeue-and-redraw forever with no
-    # other reader to ever claim it — a synchronous busy loop pinning the
-    # event loop, not a bounded wait (see #210 review finding).
-    MAX_FOREIGN_ID_REQUEUES = 5
-    foreign_id_requeue_counts: dict = {}
-
-    while True:
         try:
-            payload = await asyncio.wait_for(
-                session.response_queue.get(),
-                timeout=settings.TOOL_CALL_TIMEOUT,
+            response = await session.client.post(
+                target_url,
+                json=rpc_request,
+                headers={"Content-Type": "application/json"},
             )
-        except asyncio.TimeoutError:
-            return Response(
-                content=json.dumps(
-                    {
-                        "jsonrpc": "2.0",
-                        "id": rpc_request.get("id"),
-                        "error": {
-                            "code": -32001,
-                            "message": "Timed out waiting for Gateway response",
-                        },
-                    }
-                ),
-                status_code=504,
-                media_type="application/json",
-                headers={stream_session_header_name(): session.public_session_id},
-            )
-        if (
-            isinstance(payload, dict)
-            and payload.get("error", {}).get("message") == "Gateway SSE bridge disconnected"
-        ):
-            await close_stream_bridge_session(session.public_session_id)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Failed to send bridged request to Gateway: %s", exc)
             return Response(
                 content=json.dumps(
                     {
@@ -420,66 +366,124 @@ async def send_via_stream_bridge(
                         "id": rpc_request.get("id"),
                         "error": {
                             "code": -32000,
-                            "message": "Gateway session disconnected",
+                            "message": f"Failed to reach Gateway session: {exc}",
                         },
                     }
                 ),
                 status_code=502,
                 media_type="application/json",
+                headers={stream_session_header_name(): session.public_session_id},
+            )
+        if response.status_code not in (200, 202):
+            return Response(
+                content=response.text,
+                status_code=response.status_code,
+                media_type=response.headers.get("content-type"),
             )
 
-        if (
-            isinstance(payload, dict)
-            and "method" in payload
-            and "id" not in payload
-            and get_response_message_id(payload) != expected_id
-        ):
-            # Server-to-client notification that is not the synthetic
-            # `notifications/initialized` bridge marker — buffer for SSE delivery.
-            pending_notifications.append(payload)
-            continue
-
-        if expected_id is None or get_response_message_id(payload) == expected_id:
-            if pending_notifications:
-                body_parts = [
-                    format_sse_event(n) for n in pending_notifications
-                ]
-                body_parts.append(format_sse_event(payload))
-                return Response(
-                    content=b"".join(body_parts),
-                    status_code=200,
-                    media_type="text/event-stream",
-                    headers={stream_session_header_name(): session.public_session_id},
-                )
+        if "id" not in rpc_request:
             return Response(
-                content=json.dumps(payload),
-                status_code=200,
-                media_type="application/json",
+                status_code=202,
                 headers={stream_session_header_name(): session.public_session_id},
             )
 
-        # Response for a different concurrent call on the same session
-        # (e.g. two overlapping tools/call requests sharing one
-        # Mcp-Session-Id). Re-queue it so the caller actually waiting on
-        # that id can pick it up — but only a bounded number of times per
-        # id: if nobody ever claims it (its own call already timed out or
-        # disconnected before this arrived), stop bouncing it and drop it
-        # instead of spinning forever with no other reader left to claim it.
-        payload_id = get_response_message_id(payload)
-        requeue_count = foreign_id_requeue_counts.get(payload_id, 0) + 1
-        if requeue_count > MAX_FOREIGN_ID_REQUEUES:
-            logger.warning(
-                "Dropping orphaned Gateway response for session %s: id=%r was "
-                "requeued %d times with no caller claiming it",
-                session.public_session_id,
-                payload_id,
-                requeue_count - 1,
-            )
-            foreign_id_requeue_counts.pop(payload_id, None)
+        # Buffer server-to-client notifications that arrive before the matching
+        # response. The MCP Streamable HTTP spec lets the server answer a single
+        # POST with either a JSON body or an SSE event stream; we use the SSE
+        # path only when there's at least one notification to deliver, so the
+        # fast path for routine tool calls stays plain JSON.
+        pending_notifications: list[dict] = []
+
+        while True:
+            try:
+                payload = await asyncio.wait_for(
+                    session.response_queue.get(),
+                    timeout=settings.TOOL_CALL_TIMEOUT,
+                )
+            except asyncio.TimeoutError:
+                return Response(
+                    content=json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": rpc_request.get("id"),
+                            "error": {
+                                "code": -32001,
+                                "message": "Timed out waiting for Gateway response",
+                            },
+                        }
+                    ),
+                    status_code=504,
+                    media_type="application/json",
+                    headers={stream_session_header_name(): session.public_session_id},
+                )
+            if (
+                isinstance(payload, dict)
+                and payload.get("error", {}).get("message") == "Gateway SSE bridge disconnected"
+            ):
+                await close_stream_bridge_session(session.public_session_id)
+                return Response(
+                    content=json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": rpc_request.get("id"),
+                            "error": {
+                                "code": -32000,
+                                "message": "Gateway session disconnected",
+                            },
+                        }
+                    ),
+                    status_code=502,
+                    media_type="application/json",
+                )
+
+            if (
+                isinstance(payload, dict)
+                and "method" in payload
+                and "id" not in payload
+                and get_response_message_id(payload) != expected_id
+            ):
+                # Server-to-client notification that is not the synthetic
+                # `notifications/initialized` bridge marker — buffer for SSE delivery.
+                pending_notifications.append(payload)
+                continue
+
+            if expected_id is None or get_response_message_id(payload) == expected_id:
+                if pending_notifications:
+                    body_parts = [
+                        format_sse_event(n) for n in pending_notifications
+                    ]
+                    body_parts.append(format_sse_event(payload))
+                    return Response(
+                        content=b"".join(body_parts),
+                        status_code=200,
+                        media_type="text/event-stream",
+                        headers={stream_session_header_name(): session.public_session_id},
+                    )
+                return Response(
+                    content=json.dumps(payload),
+                    status_code=200,
+                    media_type="application/json",
+                    headers={stream_session_header_name(): session.public_session_id},
+                )
+
+            # Response for a different concurrent call on the same session
+            # (e.g. two overlapping tools/call requests sharing one
+            # Mcp-Session-Id). Re-queue it only if that id is still owned by
+            # a live waiter — otherwise its owner already timed out or
+            # disconnected and requeuing would spin forever with no other
+            # reader ever going to claim it.
+            payload_id = get_response_message_id(payload)
+            if payload_id in session.pending_response_ids:
+                await session.response_queue.put(payload)
+            else:
+                logger.warning(
+                    "Dropping orphaned Gateway response for session %s: id=%r has no live waiter",
+                    session.public_session_id,
+                    payload_id,
+                )
             continue
-        foreign_id_requeue_counts[payload_id] = requeue_count
-        await session.response_queue.put(payload)
-        continue
+    finally:
+        session.pending_response_ids.discard(expected_id)
 
 
 async def cleanup_stale_stream_bridges() -> int:

--- a/apps/api/tests/unit/test_stream_bridge_response_demux.py
+++ b/apps/api/tests/unit/test_stream_bridge_response_demux.py
@@ -85,31 +85,46 @@ async def test_concurrent_calls_each_get_their_own_response(monkeypatch):
     """Two concurrent tools/call requests on ONE shared session must each
     receive their own matching JSON-RPC response — not a 504 timeout and
     not the other call's payload — even when the Gateway answers out of
-    order (id=2's answer lands on the shared queue before id=1's)."""
-    # Keep the timeout short: this test asserts what happens once both
-    # answers are already sitting in the queue, so a slow real Gateway is
-    # not involved. If the bug is present, the affected call will genuinely
-    # block for the full timeout before returning 504.
+    order (id=2's answer lands on the shared queue before id=1's).
+
+    In production, a response can only reach the shared queue after a real
+    Gateway round trip (this call's own POST lands, the Gateway processes
+    it, its SSE reader forwards the answer) — which always takes longer
+    than the synchronous work needed to register as a waiter. So the
+    responses are injected here only once BOTH callers have registered
+    (visible via `session.pending_response_ids`), matching that ordering
+    instead of racing it against a zero-latency fake POST."""
     monkeypatch.setattr(settings, "TOOL_CALL_TIMEOUT", 1.0)
 
     session = _make_session("airis-demux-test")
     gateway_stream_bridge._stream_bridge_sessions[session.public_session_id] = session
 
-    # Simulate the Gateway answering call B (id=2) before call A (id=1),
-    # e.g. because B's tool happened to resolve faster server-side.
+    request = _FakeRequest(session.public_session_id)
+
+    task_a = asyncio.create_task(
+        gateway_stream_bridge.send_via_stream_bridge(
+            request, {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "a"}}
+        )
+    )
+    task_b = asyncio.create_task(
+        gateway_stream_bridge.send_via_stream_bridge(
+            request, {"jsonrpc": "2.0", "id": 2, "method": "tools/call", "params": {"name": "b"}}
+        )
+    )
+
+    for _ in range(200):
+        if {1, 2} <= session.pending_response_ids:
+            break
+        await asyncio.sleep(0)
+    else:
+        pytest.fail("both callers never registered as live waiters")
+
+    # Now simulate the Gateway answering call B (id=2) before call A
+    # (id=1), e.g. because B's tool happened to resolve faster server-side.
     await session.response_queue.put({"jsonrpc": "2.0", "id": 2, "result": {"for": "B"}})
     await session.response_queue.put({"jsonrpc": "2.0", "id": 1, "result": {"for": "A"}})
 
-    request = _FakeRequest(session.public_session_id)
-
-    call_a = gateway_stream_bridge.send_via_stream_bridge(
-        request, {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "a"}}
-    )
-    call_b = gateway_stream_bridge.send_via_stream_bridge(
-        request, {"jsonrpc": "2.0", "id": 2, "method": "tools/call", "params": {"name": "b"}}
-    )
-
-    response_a, response_b = await asyncio.gather(call_a, call_b)
+    response_a, response_b = await asyncio.gather(task_a, task_b)
 
     body_a = json.loads(response_a.body)
     body_b = json.loads(response_b.body)
@@ -130,20 +145,20 @@ async def test_concurrent_calls_each_get_their_own_response(monkeypatch):
 async def test_orphaned_response_is_dropped_not_requeued_forever(monkeypatch):
     """A response for an id nobody is waiting for anymore (its own caller
     already timed out / disconnected before the Gateway's late answer
-    arrived) must eventually be dropped, not requeued forever. With no
-    other reader ever going to claim it, an unbounded requeue-and-redraw
-    would spin synchronously forever (pinning the event loop) instead of
-    the caller's own wait_for() timeout ever firing. This test has no live
-    claimant for id=999 at all — the call under test (id=1) must still
-    reach its own 504 timeout promptly, proving the orphan gets dropped
-    after a bounded number of requeues rather than spun on forever."""
+    arrived) must be dropped, not requeued forever — requeuing it back
+    onto the same queue that the sole remaining reader is draining, with
+    no live owner ever going to claim it, would spin that reader in a
+    synchronous busy loop instead of letting its own wait_for() timeout
+    ever fire. This test has no live claimant for id=999 at all — the call
+    under test (id=1) must still reach its own 504 timeout promptly."""
     monkeypatch.setattr(settings, "TOOL_CALL_TIMEOUT", 1.0)
 
     session = _make_session("airis-demux-orphan-test")
     gateway_stream_bridge._stream_bridge_sessions[session.public_session_id] = session
 
     # id=999 belongs to a call that is no longer live (e.g. already timed
-    # out or disconnected) — nobody is or ever will be waiting for it.
+    # out or disconnected) — nobody is or ever will be waiting for it, so
+    # it's never in session.pending_response_ids.
     await session.response_queue.put({"jsonrpc": "2.0", "id": 999, "result": {"for": "ghost"}})
 
     request = _FakeRequest(session.public_session_id)
@@ -161,9 +176,61 @@ async def test_orphaned_response_is_dropped_not_requeued_forever(monkeypatch):
 
     body_a = json.loads(response_a.body)
     assert response_a.status_code == 504, (
-        f"expected a prompt timeout once the orphan's bounded requeues are "
-        f"exhausted, got status={response_a.status_code} body={body_a}"
+        f"expected a prompt timeout once the orphan is dropped, "
+        f"got status={response_a.status_code} body={body_a}"
     )
-    # The orphan must have been dropped (bounded retries exhausted), not
-    # left sitting in the queue forever.
+    # The orphan must have been dropped, not left sitting in the queue forever.
     assert session.response_queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_many_concurrent_callers_all_get_correct_responses(monkeypatch):
+    """Regression guard for a fixed-retry-count design that was tried and
+    rejected during #210's review: bouncing a foreign-id payload only a
+    fixed number of times (e.g. 5) before dropping it works for a couple
+    of concurrent callers, but incorrectly drops a still-live sibling's
+    response as "orphaned" once there are more concurrent callers than the
+    threshold — because a fixed count can't distinguish "several live
+    bystanders churning the queue" from "no owner left." The actual fix
+    checks live-waiter membership instead, so this must hold for an
+    arbitrarily large number of concurrent callers, not just two."""
+    monkeypatch.setattr(settings, "TOOL_CALL_TIMEOUT", 2.0)
+
+    session = _make_session("airis-demux-many-callers-test")
+    gateway_stream_bridge._stream_bridge_sessions[session.public_session_id] = session
+
+    request = _FakeRequest(session.public_session_id)
+
+    ids = list(range(1, 9))  # 8 concurrent callers — more than any small fixed retry bound
+    tasks = {
+        i: asyncio.create_task(
+            gateway_stream_bridge.send_via_stream_bridge(
+                request,
+                {"jsonrpc": "2.0", "id": i, "method": "tools/call", "params": {"name": f"call-{i}"}},
+            )
+        )
+        for i in ids
+    }
+
+    for _ in range(200):
+        if set(ids) <= session.pending_response_ids:
+            break
+        await asyncio.sleep(0)
+    else:
+        pytest.fail("not all callers registered as live waiters")
+
+    # Deliver every answer in reverse id order — maximally out-of-order —
+    # so each caller has to bounce through several foreign ids before its
+    # own arrives.
+    for i in reversed(ids):
+        await session.response_queue.put({"jsonrpc": "2.0", "id": i, "result": {"for": i}})
+
+    responses = await asyncio.gather(*(tasks[i] for i in ids))
+
+    for i, response in zip(ids, responses):
+        body = json.loads(response.body)
+        assert response.status_code == 200, (
+            f"caller id={i} did not get its response: status={response.status_code} body={body}"
+        )
+        assert body.get("id") == i
+        assert body.get("result") == {"for": i}

--- a/apps/api/tests/unit/test_stream_bridge_response_demux.py
+++ b/apps/api/tests/unit/test_stream_bridge_response_demux.py
@@ -124,3 +124,46 @@ async def test_concurrent_calls_each_get_their_own_response(monkeypatch):
     assert body_a.get("result") == {"for": "A"}
     assert body_b.get("id") == 2
     assert body_b.get("result") == {"for": "B"}
+
+
+@pytest.mark.asyncio
+async def test_orphaned_response_is_dropped_not_requeued_forever(monkeypatch):
+    """A response for an id nobody is waiting for anymore (its own caller
+    already timed out / disconnected before the Gateway's late answer
+    arrived) must eventually be dropped, not requeued forever. With no
+    other reader ever going to claim it, an unbounded requeue-and-redraw
+    would spin synchronously forever (pinning the event loop) instead of
+    the caller's own wait_for() timeout ever firing. This test has no live
+    claimant for id=999 at all — the call under test (id=1) must still
+    reach its own 504 timeout promptly, proving the orphan gets dropped
+    after a bounded number of requeues rather than spun on forever."""
+    monkeypatch.setattr(settings, "TOOL_CALL_TIMEOUT", 1.0)
+
+    session = _make_session("airis-demux-orphan-test")
+    gateway_stream_bridge._stream_bridge_sessions[session.public_session_id] = session
+
+    # id=999 belongs to a call that is no longer live (e.g. already timed
+    # out or disconnected) — nobody is or ever will be waiting for it.
+    await session.response_queue.put({"jsonrpc": "2.0", "id": 999, "result": {"for": "ghost"}})
+
+    request = _FakeRequest(session.public_session_id)
+
+    # If the orphan were requeued unconditionally, this would hang forever
+    # (a synchronous get/put spin with no other reader). The outer
+    # asyncio.wait_for is a test-level safety net, not the mechanism under
+    # test — the real assertion is the prompt 504 below.
+    response_a = await asyncio.wait_for(
+        gateway_stream_bridge.send_via_stream_bridge(
+            request, {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "a"}}
+        ),
+        timeout=5.0,
+    )
+
+    body_a = json.loads(response_a.body)
+    assert response_a.status_code == 504, (
+        f"expected a prompt timeout once the orphan's bounded requeues are "
+        f"exhausted, got status={response_a.status_code} body={body_a}"
+    )
+    # The orphan must have been dropped (bounded retries exhausted), not
+    # left sitting in the queue forever.
+    assert session.response_queue.empty()

--- a/apps/api/tests/unit/test_stream_bridge_response_demux.py
+++ b/apps/api/tests/unit/test_stream_bridge_response_demux.py
@@ -1,0 +1,126 @@
+"""Reproduce issue #210: response demux drops out-of-order concurrent replies.
+
+``StreamBridgeSession`` holds a single shared ``response_queue``. When two
+``send_via_stream_bridge()`` calls run concurrently against the same session
+(two ``tools/call`` requests sharing one ``Mcp-Session-Id``), each awaits
+``session.response_queue.get()`` in a loop looking for the JSON-RPC response
+whose ``id`` matches its own ``expected_id``.
+
+A payload that HAS an ``id`` but belongs to the OTHER concurrent call
+(``id != expected_id``) matches neither:
+
+* the "is my response" branch (`expected_id is None or get_response_message_id(payload) == expected_id`)
+* nor the "is a notification" branch (`"method" in payload and "id" not in payload`)
+
+so it falls through the ``while True`` loop and is silently dropped forever —
+never requeued for the caller that actually owns it. That caller then blocks
+until ``settings.TOOL_CALL_TIMEOUT`` and returns a 504, even though the
+Gateway already answered.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from app.api.endpoints import gateway_stream_bridge
+from app.core.config import settings
+
+
+class _FakeHeaders(dict):
+    def get(self, key, default=None):  # noqa: D401 - dict.get shadow for Request-like API
+        return super().get(key, default)
+
+
+class _FakeRequest:
+    """Minimal stand-in exposing only what get_stream_session_id() touches."""
+
+    def __init__(self, session_id: str):
+        self.headers = _FakeHeaders({gateway_stream_bridge.stream_session_header_name(): session_id})
+
+
+class _FakeGatewayResponse:
+    def __init__(self, status_code: int = 202):
+        self.status_code = status_code
+        self.text = ""
+        self.headers: dict = {}
+
+
+class _FakeGatewayClient:
+    """Stands in for httpx.AsyncClient — the POST is accepted (202), the
+    actual JSON-RPC response arrives later via the shared response_queue,
+    exactly like the real Gateway's SSE-fan-out flow."""
+
+    async def post(self, *args, **kwargs):
+        return _FakeGatewayResponse(status_code=202)
+
+
+@pytest.fixture(autouse=True)
+def clear_bridge_state():
+    gateway_stream_bridge._stream_bridge_sessions.clear()
+    yield
+    gateway_stream_bridge._stream_bridge_sessions.clear()
+
+
+def _make_session(public_session_id: str) -> gateway_stream_bridge.StreamBridgeSession:
+    return gateway_stream_bridge.StreamBridgeSession(
+        public_session_id=public_session_id,
+        backend_session_id="backend-session-xyz",
+        client=_FakeGatewayClient(),
+        stream_context=object(),
+        stream_response=object(),
+        # Session "born" long ago so send_via_stream_bridge() skips the
+        # STREAM_BRIDGE_READY_DELAY settle-sleep for both callers. Without
+        # this, the two callers' sleep durations differ by the few
+        # microseconds between their monotonic() reads, which flips which
+        # one reaches the response_queue first and can mask the race this
+        # test targets.
+        created_at=0.0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_concurrent_calls_each_get_their_own_response(monkeypatch):
+    """Two concurrent tools/call requests on ONE shared session must each
+    receive their own matching JSON-RPC response — not a 504 timeout and
+    not the other call's payload — even when the Gateway answers out of
+    order (id=2's answer lands on the shared queue before id=1's)."""
+    # Keep the timeout short: this test asserts what happens once both
+    # answers are already sitting in the queue, so a slow real Gateway is
+    # not involved. If the bug is present, the affected call will genuinely
+    # block for the full timeout before returning 504.
+    monkeypatch.setattr(settings, "TOOL_CALL_TIMEOUT", 1.0)
+
+    session = _make_session("airis-demux-test")
+    gateway_stream_bridge._stream_bridge_sessions[session.public_session_id] = session
+
+    # Simulate the Gateway answering call B (id=2) before call A (id=1),
+    # e.g. because B's tool happened to resolve faster server-side.
+    await session.response_queue.put({"jsonrpc": "2.0", "id": 2, "result": {"for": "B"}})
+    await session.response_queue.put({"jsonrpc": "2.0", "id": 1, "result": {"for": "A"}})
+
+    request = _FakeRequest(session.public_session_id)
+
+    call_a = gateway_stream_bridge.send_via_stream_bridge(
+        request, {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "a"}}
+    )
+    call_b = gateway_stream_bridge.send_via_stream_bridge(
+        request, {"jsonrpc": "2.0", "id": 2, "method": "tools/call", "params": {"name": "b"}}
+    )
+
+    response_a, response_b = await asyncio.gather(call_a, call_b)
+
+    body_a = json.loads(response_a.body)
+    body_b = json.loads(response_b.body)
+
+    assert response_a.status_code == 200, (
+        f"caller A (id=1) did not get its response: status={response_a.status_code} body={body_a}"
+    )
+    assert response_b.status_code == 200, (
+        f"caller B (id=2) did not get its response: status={response_b.status_code} body={body_b}"
+    )
+    assert body_a.get("id") == 1
+    assert body_a.get("result") == {"for": "A"}
+    assert body_b.get("id") == 2
+    assert body_b.get("result") == {"for": "B"}


### PR DESCRIPTION
Fixes #210

## What / why

`send_via_stream_bridge()` (`apps/api/src/app/api/endpoints/gateway_stream_bridge.py:380-450`) drains a per-session `response_queue` shared by every concurrent `tools/call` on the same `Mcp-Session-Id`. A dequeued payload with an `id` belonging to a *different* concurrent call (not this call's `expected_id`, not a notification) matched neither handling branch and was silently dropped — the rightful caller then spuriously timed out with a 504 even though the Gateway had already answered.

Fix: re-queue such mismatched, non-notification payloads back onto `session.response_queue` and `continue`, so the caller that actually owns that id picks it up on a later iteration. The existing own-id-match and notification-buffering branches are unchanged.

## Test plan

- [x] New regression test `apps/api/tests/unit/test_stream_bridge_response_demux.py` — two concurrent `send_via_stream_bridge()` calls on one shared session, Gateway answers out of order. Observed RED (504) against the pre-fix code, GREEN after the fix.
- [x] `cd apps/api && uv run --extra test python -m pytest tests/unit -v` → 503 passed (502 pre-existing + 1 new).