### PR TITLE
fix: exempt the actual long-lived SSE stream paths from the rate limiter (Fixes #211)

### DIFF
--- a/apps/api/src/app/middleware/rate_limit.py
+++ b/apps/api/src/app/middleware/rate_limit.py
@@ -33,22 +33,31 @@ RATE_LIMIT_WINDOW = 60  # seconds (fixed at 1 minute)
 # Paths excluded from rate limiting (monitoring endpoints)
 EXCLUDED_PATHS = frozenset({"/health", "/ready", "/metrics"})
 
-# MCP Streamable HTTP transport paths (see main.py's `include_router(mcp_proxy.router,
-# prefix="/mcp")` and `mcp_proxy.py`'s `/.well-known/{path:path}` route). GET/HEAD on
-# these paths are NOT per-request traffic: per the MCP Streamable HTTP spec
-# (2025-11-25), GET opens a long-lived server->client SSE stream (and resumes it after
-# a disconnect via `Last-Event-ID`), and `/.well-known/*` is a one-shot discovery
-# probe. A single MCP client can hold one GET stream open for hours and reconnect
-# many times; counting each of those against the fixed-window counter would exhaust
-# the budget fast. Because this gateway binds to localhost, every local MCP client
-# (Claude Code, Cursor, Codex, ...) shares the same 127.0.0.1 IP key, so counting
-# GET/HEAD here would lock out ALL of them from a single client's reconnect storm.
-# POST (JSON-RPC calls) and DELETE (session termination) are genuine per-request
-# traffic and stay rate-limited below.
-# This exemption is only safe because the gateway is localhost/trusted-proxy bound;
-# a public-facing deployment should instead cap concurrent SSE connections per key
-# rather than exempting GET/HEAD outright.
-MCP_TRANSPORT_READ_PATHS = frozenset({"/mcp", "/mcp/"})
+# MCP Streamable HTTP / SSE transport paths. GET/HEAD on these paths are NOT
+# per-request traffic: per the MCP Streamable HTTP spec (2025-11-25), GET opens
+# a long-lived server->client SSE stream (and resumes it after a disconnect via
+# `Last-Event-ID`), and `/.well-known/*` is a one-shot discovery probe. A single
+# MCP client can hold one GET stream open for hours and reconnect many times;
+# counting each of those against the fixed-window counter would exhaust the
+# budget fast. Because this gateway binds to localhost, every local MCP client
+# (Claude Code, Cursor, Codex, ...) shares the same 127.0.0.1 IP key, so
+# counting GET/HEAD here would lock out ALL of them from a single client's
+# reconnect storm. POST (JSON-RPC calls) and DELETE (session termination) are
+# genuine per-request traffic and stay rate-limited below.
+#
+# Covers every actual long-lived GET route, not just the instant health-check
+# ping at the bare "/mcp" path (see main.py's `include_router(mcp_proxy.router,
+# prefix="/mcp")`):
+#   - "/mcp", "/mcp/"  -> mcp_proxy.py's `@router.get("")`/`@router.get("/")`
+#     health-check GET (instant, not a stream, but harmless to also exempt).
+#   - "/mcp/sse"       -> mcp_proxy.py's `@router.get("/sse")`, the Streamable
+#     HTTP resumable GET stream (issue #211 — this one was missing).
+#   - "/sse"           -> main.py's `@app.get("/sse")`, the classic SSE
+#     transport used by Gemini CLI / Cursor / Windsurf (also missing).
+# This exemption is only safe because the gateway is localhost/trusted-proxy
+# bound; a public-facing deployment should instead cap concurrent SSE
+# connections per key rather than exempting GET/HEAD outright.
+MCP_TRANSPORT_READ_PATHS = frozenset({"/mcp", "/mcp/", "/mcp/sse", "/sse"})
 MCP_WELL_KNOWN_PREFIX = "/.well-known/"
 
 # Trusted proxy CIDRs — only trust X-Forwarded-For from these sources.

--- a/apps/api/tests/unit/test_rate_limit_mcp_exempt.py
+++ b/apps/api/tests/unit/test_rate_limit_mcp_exempt.py
@@ -23,6 +23,8 @@ def _build_client() -> TestClient:
         routes=[
             Route("/mcp", _ok, methods=["GET", "HEAD"]),
             Route("/mcp/", _ok, methods=["GET", "HEAD"]),
+            Route("/mcp/sse", _ok, methods=["GET", "HEAD"]),
+            Route("/sse", _ok, methods=["GET", "HEAD"]),
             Route("/api/v1/data", _ok, methods=["POST"]),
         ]
     )
@@ -50,6 +52,29 @@ def test_head_mcp_beyond_limit_is_exempt():
 
     for _ in range(150):
         response = client.head("/mcp")
+        assert response.status_code == 200
+
+
+def test_get_mcp_sse_stream_beyond_limit_is_exempt():
+    """Regression test for #211: the Streamable HTTP resumable GET stream at
+    `/mcp/sse` — the long-lived route the exemption comment actually
+    describes — was missing from MCP_TRANSPORT_READ_PATHS, so a reconnect
+    storm on this exact path could still 429-lock out every local client."""
+    client = _build_client()
+
+    for _ in range(150):
+        response = client.get("/mcp/sse")
+        assert response.status_code == 200
+
+
+def test_get_classic_sse_beyond_limit_is_exempt():
+    """Regression test for #211: the classic SSE transport at `/sse`
+    (Gemini CLI / Cursor / Windsurf per this repo's CLAUDE.md) was also
+    missing from the exemption."""
+    client = _build_client()
+
+    for _ in range(150):
+        response = client.get("/sse")
         assert response.status_code == 200
 
 


### PR DESCRIPTION
Fixes #211

## What / why

`MCP_TRANSPORT_READ_PATHS` (added in #208 to stop long-lived MCP GET streams / reconnect storms from exhausting the shared-localhost per-IP rate limit) only ever matched the bare `/mcp` health-check path — an instant, non-streaming GET. The actual long-lived streams the fix's own comment described, `/mcp/sse` (Streamable HTTP resumable stream) and `/sse` (classic SSE transport for Gemini CLI/Cursor/Windsurf), were never covered, so the reconnect-storm risk the fix targeted was still fully live on those paths.

Add `/mcp/sse` and `/sse` to the exemption set.

## Test plan

- [x] New tests `test_get_mcp_sse_stream_beyond_limit_is_exempt` / `test_get_classic_sse_beyond_limit_is_exempt` in `apps/api/tests/unit/test_rate_limit_mcp_exempt.py` — observed RED (429) against pre-fix code, GREEN after.
- [x] `cd apps/api && uv run --extra test python -m pytest tests/unit -q` → 507 passed.