### PR TITLE
docs: drop policy-disabled cloudflare from routing guidance docs (Fixes #212)

### DIFF
--- a/apps/api/tests/unit/test_registry_docs_drift.py
+++ b/apps/api/tests/unit/test_registry_docs_drift.py
@@ -55,9 +55,12 @@ DISQUALIFIERS = (
 SCAN_FILES = [
     "README.md",
     "CLAUDE.md",
-    "docs/architecture.md",
     "config/toolsets.json",
     "catalogs/airis-catalog.yaml",
+    # All of docs/*.md, not just architecture.md — issue #212 found
+    # gateway-vs-plugins.md silently advertising a FORBIDDEN_SERVERS entry
+    # because it was outside this list's scope.
+    *sorted(str(p.relative_to(REPO_ROOT)) for p in (REPO_ROOT / "docs").glob("*.md")),
     *sorted(str(p.relative_to(REPO_ROOT)) for p in (REPO_ROOT / "workflows").glob("*.yaml")),
 ]
 

--- a/docs/capability-selection.md
+++ b/docs/capability-selection.md
@@ -28,7 +28,6 @@ Good fits:
 
 - Stripe
 - Supabase
-- Cloudflare
 - GitHub API
 - Tavily
 

--- a/docs/gateway-vs-plugins.md
+++ b/docs/gateway-vs-plugins.md
@@ -37,7 +37,6 @@ Plugins (host-dependent):     MCP Gateway (Docker-isolated):
 ├── superpowers (workflow)    ├── tavily (cold)
 └── playwright-cli (browser)  ├── supabase (cold)
                               ├── stripe (cold)
-                              ├── cloudflare (cold)
                               └── ... (20+ more, zero cost when cold)
 ```
 


### PR DESCRIPTION
Fixes #212

## What / why

`docs/gateway-vs-plugins.md` and `docs/capability-selection.md` both listed `cloudflare` as a live, callable Gateway server. It's `enabled: false, policy_disabled: true` in `mcp-config.json.example` — never advertised, never run — the exact class of drift issue #193 already forbids (`FORBIDDEN_SERVERS` in `test_registry_docs_drift.py`). These two files just weren't in the drift test's scan scope.

Also widened `SCAN_FILES` to glob all of `docs/*.md` instead of only `docs/architecture.md`, so this drift class can't reappear silently in an unscanned doc — this immediately caught the `capability-selection.md` instance too.

## Test plan

- [x] `cd apps/api && uv run --extra test python -m pytest tests/unit/test_registry_docs_drift.py -v` → 28 passed (10 new parametrized cases from the widened doc glob).
- [x] `cd apps/api && uv run --extra test python -m pytest tests/unit -q` → 517 passed.