### PR TITLE
docs: architecture.md matches the shipped 4-meta-tool + direct-COLD-exposure model (Fixes #213)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,35 +61,43 @@ another server's responses.
 ## Current architecture
 
 Dynamic MCP keeps the initial tool surface small while still allowing direct calls to
-native MCP tools. As shipped today the control plane exposes **two meta-tools**:
+native MCP tools. As shipped today (`DYNAMIC_MCP=true`, the default) the control plane
+exposes **4 meta-tools**, plus — when `COLD_TOOLS_IN_LIST=true` (also the default) —
+every discoverable COLD server's indexed tools with a lazy stub schema
+(`{"type":"object"}`) sitting directly in `tools/list`, instead of only the older
+meta-tool-only surface:
 
 | Tool | Purpose |
 |------|---------|
-| `airis-find` | Discover tools across server/tool metadata |
-| `airis-schema` | Get the input schema for a native tool when arguments are unclear |
+| `airis-find` | Discover tools across server/tool metadata (optional discovery aid) |
+| `airis-schema` | Get a tool's full input schema on demand |
+| `airis-workflow` | Fetch a task-specific procedure by `topic` (on-demand `workflows/*.yaml` recipes) |
+| `airis-exec` | Compat router: execute any tool by name/`server:tool`, for clients that can't act on a bare `tools/list` name |
 
 `META_TOOLS_MODE=full` adds `airis-confidence`, `airis-repo-index`, `airis-suggest`,
-`airis-route`.
+`airis-route`. Set `COLD_TOOLS_IN_LIST=false` to fall back to the old meta-tool-only
+listing for context-constrained clients.
 
 ### Request flow
 
-1. `tools/list` returns the meta-tools plus any already-active HOT server tools
-2. The model uses `airis-find` to locate the capability it needs
-3. The model calls the COLD tool through `airis-exec` (`tool="server:tool"`, `arguments={…}`)
-4. `airis-exec` auto-discovers and auto-enables the COLD server on first call, then runs the tool
-
-`airis-exec` is the router for COLD tools: they are not in `tools/list`, and
-`tools/list`-only clients (Claude Code, Codex) can only call advertised tools, so a
-single always-advertised router is required to reach them. Use `airis-schema` to get a
-tool's argument schema before calling `airis-exec`.
+1. `tools/list` returns the meta-tools, any already-active HOT server tools (full
+   schema), and every discoverable COLD server's tools (lazy stub schema) — all listed
+   directly, no meta-tool round trip needed to see them.
+2. The model calls a COLD tool by the name it already saw in `tools/list`
+   (`tools/call`) — one hop. The server auto-discovers and auto-enables that COLD
+   server on this first call, then runs the tool.
+3. `airis-find`/`airis-schema` remain available for browsing servers and fetching full
+   schemas when the stub schema isn't enough to know what to pass. `airis-workflow`
+   fetches a task-specific procedure by topic. `airis-exec` remains as a compat router
+   for clients that can't call a bare `tools/list` name directly.
 
 ### Hot / cold / disabled
 
 | State | Behavior | Examples |
 |-------|----------|----------|
-| **HOT** | Pre-warmed at startup, always listed in `tools/list`, never idle-killed | `context7`, `airis-mcp-gateway-control`, `airis-workspace` |
-| **COLD** | Started on first tool call, stopped after idle timeout, restarted transparently | Stripe, Tavily, browser automation |
-| **Disabled** | Gated by policy or absent credentials | Supabase (never authorized), dangerous write/admin integrations, niche providers |
+| **HOT** | Pre-warmed at startup, always listed in `tools/list` with full schema, never idle-killed | `context7`, `airis-mcp-gateway-control`, `airis-workspace` |
+| **COLD** | Listed directly in `tools/list` with a lazy stub schema; starts on first tool call, stops after idle timeout, restarts transparently | Stripe, Tavily, browser automation |
+| **Disabled** | Gated by policy or absent credentials — never advertised, never run | Supabase (never authorized), dangerous write/admin integrations, niche providers |
 
 ```
 Claude Code
@@ -97,11 +105,11 @@ Claude Code
     v
 airis-mcp-gateway (port 9400)
     |
-    +-- Dynamic MCP control plane (airis-find, airis-schema)
+    +-- Dynamic MCP control plane (airis-find, airis-schema, airis-workflow, airis-exec)
     |
     +-- Native helpers (airis-confidence, airis-repo-index, airis-suggest, airis-route)
     |
-    +-- MCP proxy --> Docker MCP Gateway --> mindbase, time, etc.
+    +-- MCP proxy --> Docker MCP Gateway --> mindbase, time, etc. (COLD, direct tools/list exposure)
     |
     +-- Process mgmt --> context7, stripe, playwright, etc.
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -141,8 +141,9 @@ Dynamic MCP exposes a small control plane instead of a giant flat catalog.
 
 ## Target direction
 
-> **Status:** direction, not yet shipped. The current control plane uses
-> `airis-find` / `airis-schema`; the toolset/`airis-activate` model below is the
+> **Status:** direction, not yet shipped. The current control plane is the 4-meta-tool
+> + direct-COLD-exposure model described above (`airis-find` / `airis-schema` /
+> `airis-workflow` / `airis-exec`); the toolset/`airis-activate` model below is the
 > target. See [toolset-roadmap.md](./toolset-roadmap.md) for the phased plan.
 
 AIRIS should evolve from a **server-centric Dynamic MCP** into a **toolset-centric
@@ -197,7 +198,7 @@ resources, project skills, hooks, or repo docs — not in tool descriptions.
 |--------|----------|---------------------|--------------------|
 | Initial tool surface | Huge | Small | Small |
 | Primary execution path | Native tools | Native tools (auto-enable) | Native tools (toolset-activated) |
-| Discovery style | Implicit | meta-tool (`airis-find`) | activation-first |
+| Discovery style | Implicit | direct `tools/list` (stub schema) + meta-tool aid | activation-first |
 | Large-provider handling | Poor | Better | Better and simpler |
 
 ---
@@ -214,7 +215,9 @@ resources, project skills, hooks, or repo docs — not in tool descriptions.
 ### Non-goals
 
 - one OS process per individual tool
-- exposing every provider tool directly in `tools/list`
+- exposing every provider tool with a full schema directly in `tools/list` (the
+  shipped lazy stub-schema COLD listing avoids this cost; full schemas are still
+  fetched on demand via `airis-schema`/`expandSchema`)
 - storing workflow knowledge only inside tool descriptions
 - using MCP for host-local deterministic workflows better served by CLI or skills
 - making a proxy meta-tool (`airis-exec`) the long-term primary interface

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -156,10 +156,12 @@ capability gateway**, keeping these boundaries:
 
 ### Why the current design is not enough
 
-The current design is directionally correct (avoid exposing every tool, keep rarely
-used servers cold, route through a few meta-tools), but it still has a scaling problem:
+The current design is directionally correct (avoid exposing every tool with a full
+schema, keep rarely used servers cold, list COLD tools with a lazy stub schema plus a
+few meta-tools for discovery), but it still has a scaling problem:
 
-- broad meta-tool descriptions still leak too much capability metadata into the initial context
+- listing every discoverable COLD server's tools still leaks a name + stub entry per
+  tool into the initial `tools/list`, even before any schema is fetched
 - server-level exposure is too coarse for providers with dozens of tools
 
 ### Exposure at the toolset layer


### PR DESCRIPTION
Fixes #213

## What / why

`docs/architecture.md`'s "Current architecture" section (this file's own declared "what ships today" source of truth) still described the pre-#193-198 model: "two meta-tools" (`airis-find`, `airis-schema`) with `airis-exec` as the only path to a COLD tool. That's stale — CLAUDE.md and README.md (post-#209) already correctly describe **4 meta-tools** (`airis-find`, `airis-schema`, `airis-workflow`, `airis-exec`) plus every discoverable COLD server's tools listed directly in `tools/list` with a lazy stub schema, callable by name in one hop without an `airis-exec` round trip. `airis-workflow` wasn't mentioned anywhere in this file.

Rewrote the meta-tools table, request flow, hot/cold/disabled table, and control-plane ASCII diagram to match CLAUDE.md's Dynamic MCP section. Left the "Target direction" section untouched — it's explicitly marked "not yet shipped," a separate forward-looking design question out of scope for this drift fix.

## Test plan

- [x] `cd apps/api && uv run --extra test python -m pytest tests/unit/test_registry_docs_drift.py -q` → 28 passed (no server-name drift introduced).
- [x] `cd apps/api && uv run --extra test python -m pytest tests/unit -q` → 517 passed.